### PR TITLE
Open Links in new Tab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"cSpell.words": [
+		"Katex",
+		"Pluggable",
+		"rehype"
+	]
 }

--- a/libs/ui/forms/src/lib/markdown-editor.tsx
+++ b/libs/ui/forms/src/lib/markdown-editor.tsx
@@ -35,7 +35,7 @@ export function MarkdownField({
 				style={{ minHeight: 32 }}
 			>
 				<div className="prose prose-emerald max-w-full">
-					<ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+					<ReactMarkdown linkTarget='_blank' remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
 						{content ?? ""}
 					</ReactMarkdown>
 				</div>
@@ -100,6 +100,7 @@ export function MarkdownEditorDialog({
 					<div className="relative flex h-full w-full grow overflow-auto border border-light-border bg-white p-4">
 						<div className="prose prose-emerald w-full">
 							<ReactMarkdown
+                                linkTarget='_blank'
 								remarkPlugins={remarkPlugins}
 								rehypePlugins={rehypePlugins}
 							>
@@ -126,7 +127,7 @@ export function MarkdownEditorDialog({
  */
 export function MarkdownViewer({ content }: { content: string }) {
 	return (
-		<ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+		<ReactMarkdown linkTarget='_blank' remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
 			{content ?? ""}
 		</ReactMarkdown>
 	);

--- a/libs/util/markdown/src/lib/markdown.ts
+++ b/libs/util/markdown/src/lib/markdown.ts
@@ -6,9 +6,10 @@ import remarkMath from "remark-math";
 // Rehype packages
 import rehypeKatex from "rehype-katex";
 import rehypePrismPlus from "rehype-prism-plus";
+import rehypeExternalLinks from "rehype-external-links";
 
 export const remarkPlugins = [remarkGfm, remarkMath];
-export const rehypePlugins = [rehypeKatex, rehypePrismPlus];
+export const rehypePlugins = [rehypeKatex, rehypePrismPlus, [rehypeExternalLinks, {target: "_blank"}]];
 
 /**
  * Converts a markdown document to an object that can be rendered in a {@link MDXRemote} component.

--- a/libs/util/markdown/src/lib/markdown.ts
+++ b/libs/util/markdown/src/lib/markdown.ts
@@ -1,15 +1,19 @@
 import { serialize } from "next-mdx-remote/serialize";
-
-// Remark packages
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
+import rehypeExternalLinks from "rehype-external-links";
 // Rehype packages
 import rehypeKatex from "rehype-katex";
 import rehypePrismPlus from "rehype-prism-plus";
-import rehypeExternalLinks from "rehype-external-links";
+// Remark packages
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import { Pluggable } from "unified";
 
 export const remarkPlugins = [remarkGfm, remarkMath];
-export const rehypePlugins = [rehypeKatex, rehypePrismPlus, [rehypeExternalLinks, {target: "_blank"}]];
+export const rehypePlugins = [
+	rehypeKatex,
+	rehypePrismPlus,
+	[rehypeExternalLinks, { target: "_blank" }] as Pluggable
+];
 
 /**
  * Converts a markdown document to an object that can be rendered in a {@link MDXRemote} component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "self-learning",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "self-learning",
-			"version": "0.0.0",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@headlessui/react": "^1.7.7",
@@ -42,6 +42,7 @@
 				"react-player": "^2.10.1",
 				"regenerator-runtime": "0.13.7",
 				"rehype-citation": "^0.4.0",
+				"rehype-external-links": "^2.0.1",
 				"rehype-katex": "^6.0.2",
 				"rehype-preset-minify": "^6.0.0",
 				"rehype-prism-plus": "^1.4.0",
@@ -14848,6 +14849,17 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/is-absolute-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+			"integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-arguments": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -23190,6 +23202,23 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/rehype-external-links": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-2.0.1.tgz",
+			"integrity": "sha512-u2dNypma+ps12SJWlS23zvbqwNx0Hl24t0YHXSM/6FCZj/pqWETCO3WyyrvALv4JYvRtuPjhiv2Lpen15ESqbA==",
+			"dependencies": {
+				"@types/hast": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-absolute-url": "^4.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"unified": "^10.0.0",
+				"unist-util-visit": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/rehype-katex": {
@@ -38937,6 +38966,11 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
+		"is-absolute-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+			"integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A=="
+		},
 		"is-arguments": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -44860,6 +44894,19 @@
 					"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
 					"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
 				}
+			}
+		},
+		"rehype-external-links": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-2.0.1.tgz",
+			"integrity": "sha512-u2dNypma+ps12SJWlS23zvbqwNx0Hl24t0YHXSM/6FCZj/pqWETCO3WyyrvALv4JYvRtuPjhiv2Lpen15ESqbA==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"extend": "^3.0.0",
+				"is-absolute-url": "^4.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"unified": "^10.0.0",
+				"unist-util-visit": "^4.0.0"
 			}
 		},
 		"rehype-katex": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"react-player": "^2.10.1",
 		"regenerator-runtime": "0.13.7",
 		"rehype-citation": "^0.4.0",
+		"rehype-external-links": "^2.0.1",
 		"rehype-katex": "^6.0.2",
 		"rehype-preset-minify": "^6.0.0",
 		"rehype-prism-plus": "^1.4.0",


### PR DESCRIPTION
Added a fix to open link rendered in markdown in new Tab. I had to add a new Package [rehype-external-links](https://github.com/rehypejs/rehype-external-links), the fix is working however it does currently throw a lint error and i'm not sure how to fix it.

![grafik](https://user-images.githubusercontent.com/25080047/216576727-8ad606da-c82a-4f1a-afe3-5182a53893e6.png)


Closes #25