### PR TITLE
fix(teaching): Selection of authors/learning units/subjects via DropDownDialog fix

### DIFF
--- a/libs/feature/admin/src/lib/search-course-dialog.tsx
+++ b/libs/feature/admin/src/lib/search-course-dialog.tsx
@@ -30,7 +30,7 @@ export function SearchCourseDialog({
 
 	return (
 		<DropdownDialog.Dialog open={open} onClose={onClose}>
-			<Combobox value={null} onClose={onClose}>
+			<Combobox value={null}>
 				<DropdownDialog.SearchInput
 					filter={title}
 					setFilter={setTitle}
@@ -47,6 +47,7 @@ export function SearchCourseDialog({
 							{({ focus }) => (
 								<button
 									type="button"
+									onClick={() => onClose(course)}
 									data-testid="course-option"
 									className={`flex items-center gap-4 rounded px-4 py-2 ${
 										focus ? "bg-secondary text-white" : ""

--- a/libs/feature/teaching/src/lib/author/add-author-dialog.tsx
+++ b/libs/feature/teaching/src/lib/author/add-author-dialog.tsx
@@ -33,7 +33,7 @@ export function AddAuthorDialog({
 
 	return (
 		<DropdownDialog.Dialog open={open} onClose={onClose}>
-			<Combobox value={null} onClose={onClose}>
+			<Combobox value={null}>
 				<DropdownDialog.SearchInput
 					filter={filter}
 					setFilter={setFilter}
@@ -46,6 +46,7 @@ export function AddAuthorDialog({
 							{({ focus }) => (
 								<button
 									type="button"
+									onClick={() => onClose(author)}
 									data-testid="author-option"
 									className={`flex items-center gap-4 rounded px-4 py-2 ${
 										focus ? "bg-secondary text-white" : ""

--- a/libs/feature/teaching/src/lib/course/course-content-editor/dialogs/lesson-selector.tsx
+++ b/libs/feature/teaching/src/lib/course/course-content-editor/dialogs/lesson-selector.tsx
@@ -22,7 +22,7 @@ export function LessonSelector({
 
 	return (
 		<DropdownDialog.Dialog open={open} onClose={onClose}>
-			<Combobox value={null} onClose={onClose}>
+			<Combobox value={null}>
 				<DropdownDialog.SearchInput
 					filter={title}
 					setFilter={setTitle}
@@ -39,6 +39,7 @@ export function LessonSelector({
 							{({ focus }) => (
 								<button
 									type="button"
+									onClick={() => onClose(lesson)}
 									className={`flex flex-col gap-1 rounded px-4 py-2 ${
 										focus ? "bg-secondary text-white" : ""
 									}`}

--- a/libs/feature/teaching/src/lib/subject/subject-selector.tsx
+++ b/libs/feature/teaching/src/lib/subject/subject-selector.tsx
@@ -4,7 +4,7 @@ import { DropdownDialog, ImageOrPlaceholder, OnDialogCloseFn } from "@self-learn
 import { Fragment, useMemo, useState } from "react";
 
 /**
- * Dialog that allows the user to select an author from a list of authors.
+ * Dialog to select an existing specialization.
  */
 export function SpecializationSelector({
 	onClose,
@@ -35,7 +35,7 @@ export function SpecializationSelector({
 
 	return (
 		<DropdownDialog.Dialog open={open} onClose={onClose}>
-			<Combobox value={null} onClose={onClose}>
+			<Combobox value={null}>
 				<DropdownDialog.SearchInput
 					filter={filter}
 					setFilter={setFilter}
@@ -58,6 +58,7 @@ export function SpecializationSelector({
 										{({ focus }) => (
 											<button
 												type="button"
+												onClick={() => onClose(spec)}
 												className={`flex items-center gap-4 rounded pr-4 ${
 													focus ? "bg-secondary text-white" : ""
 												}`}


### PR DESCRIPTION
- Keine Ahnung warum die bisherige Lösung auf einmal nicht mehr funktioniert, ich habe an den geänderten stellen keine Commits in den letzten 3 Monaten bemerkt. Dafür schien es an allen Stellen mit der bisherigen Variante nicht zu funktionieren. Ich vermute Änderung/Update am Framework?

- `SpecializationSelector` wird in `SpecializationForm`verwendet, habe aber nicht gefunden wo `SpecializationForm` verwendet wird. Handelt es sich hierbei um DeadCode? Habe trotzdem den Code wie die anderen Componenten angepasst. Konnte es im Gegensatz zu den anderen Komponenten nicht testen.

Closes #274 