### PR TITLE
Fix(learning-editor)"Generieren" doesn't close Learning Edit Dialog anymore

### DIFF
--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
@@ -62,7 +62,7 @@ export function LessonInfoEditor({ lesson }: { lesson?: LessonFormModel }) {
 							/>
 						}
 						button={
-							<GreyBoarderButton onClick={slugifyField} title={"Generiere Slug"}>
+							<GreyBoarderButton type="button" onClick={slugifyField} title={"Generiere Slug"}>
 								<span className={"text-gray-600"}>Generieren</span>
 							</GreyBoarderButton>
 						}


### PR DESCRIPTION
Fixed the generate slug button in learning edit dialog and edit course to not close the dialog and not safe the changes.