### PR TITLE
fix(markdown-editor) deleting content now works correctly

### DIFF
--- a/libs/ui/forms/src/lib/markdown-editor.tsx
+++ b/libs/ui/forms/src/lib/markdown-editor.tsx
@@ -93,7 +93,7 @@ export function MarkdownEditorDialog({
 					{editorInstance && <EditorQuickActions editor={editorInstance} />}
 					<EditorField
 						language="markdown"
-						onChange={value => value && setValue(value)}
+						onChange={value => setValue(value ?? "")}
 						onMount={handleEditorDidMount}
 						value={value}
 						height={"100%"}


### PR DESCRIPTION
Fixed a bug where the last letter after deleting a word in the markdown editor is staying in place.