### PR TITLE
fix(quiz-editor) Markdown editor is now opened directly when adding something to a Categorie

### DIFF
--- a/libs/feature/question-types/src/lib/question-types/arrange/form.tsx
+++ b/libs/feature/question-types/src/lib/question-types/arrange/form.tsx
@@ -1,4 +1,8 @@
-import { LabeledField, MarkdownField, MarkdownViewer } from "@self-learning/ui/forms";
+import {
+	LabeledField,
+	MarkdownEditorDialog,
+	MarkdownViewer
+} from "@self-learning/ui/forms";
 import { Fragment, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { QuestionTypeForm } from "../../base-question";
@@ -252,26 +256,22 @@ function EditItemDialog({
 	item?: ArrangeItem;
 	onClose: OnDialogCloseFn<ArrangeItem>;
 }) {
-	const [content, setContent] = useState(item?.content ?? "");
-
+	const [isEditorOpen, setIsEditorOpen] = useState(true);
+	
 	return (
-		<Dialog className="w-[80vw]" title={item ? "Bearbeiten" : "Hinzufügen"} onClose={onClose}>
-			<MarkdownField content={content} setValue={value => setContent(value ?? "")} />
-
-			<DialogActions onClose={onClose}>
-				<button
-					type="button"
-					className="btn-primary"
-					onClick={() =>
-						onClose({
-							id: item?.id ?? getRandomId(),
-							content
-						})
+		isEditorOpen && (
+			<MarkdownEditorDialog
+				title="Markdown bearbeiten"
+				initialValue={item?.content ?? ""}
+				onClose={newValue => {
+					setIsEditorOpen(false);
+					if (newValue !== undefined) {
+						onClose({ id: item?.id ?? getRandomId(), content: newValue });
+					} else {
+						onClose(undefined);
 					}
-				>
-					{item ? "Übernehmen" : "Hinzufügen"}
-				</button>
-			</DialogActions>
-		</Dialog>
+				}}
+			/>
+		)
 	);
 }


### PR DESCRIPTION
At first after a adding a Categorie in the Learncontrol editor a popup was opened that you had to click on again to get to the markdown editor. 
Now if you press add or the pencil icon you will immediatly get redirected to the markdown-editor, where you can make your changes.