### PR TITLE
Feat/content removal fix

### DIFF
--- a/libs/data-access/api/src/lib/trpc/routers/course.router.trpc.spec.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/course.router.trpc.spec.ts
@@ -1,0 +1,114 @@
+import { database } from "@self-learning/database";
+import { Context, UserFromSession } from "../context";
+import { courseRouter } from "./course.router";
+import { t } from "../trpc";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import { TRPCError } from "@trpc/server";
+
+jest.mock("@self-learning/database", () => ({
+	__esModule: true,
+	database: {
+		course: {
+			delete: jest.fn()
+		}
+	}
+}));
+
+function prepare(user: Partial<UserFromSession>) {
+	const ctx: Context = {
+		user: {
+			id: "user-id",
+			name: "john",
+			role: "USER",
+			isAuthor: false,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false,
+			...user
+		}
+	};
+	const caller = t.createCallerFactory(courseRouter)(ctx);
+	return caller;
+}
+
+describe("tRPC API of Course Router", () => {
+	describe("deleteCourse", () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			(database.course.delete as jest.Mock).mockImplementation(({ where }) => {
+				// Require
+				// - Slug: "test-course"
+				// - Authors: "author1" or "author2"
+				if (
+					where.slug === "test-course" &&
+					(where.authors.some.username === "author1" ||
+						where.authors.some.username === "author2")
+				) {
+					return Promise.resolve({
+						slug: "test-course",
+						authors: [{ username: "author1" }]
+					});
+				} else {
+					throw new PrismaClientKnownRequestError(
+						"No Course found for specified where condition",
+						{ code: "P2025", clientVersion: "4.0.0" } // Mocked error code & version
+					);
+				}
+			});
+		});
+
+		it("should delete a course if user is author", async () => {
+			const caller = prepare({
+				isAuthor: true,
+				name: "author1"
+			});
+			const input = { slug: "test-course" };
+
+			// Course exists; user is author -> Success
+			await expect(caller.deleteCourse(input)).resolves.not.toThrow();
+		});
+
+		it("should delete a course if user second author", async () => {
+			const caller = prepare({
+				isAuthor: true,
+				name: "author2"
+			});
+			const input = { slug: "test-course" };
+
+			// Course exists; user is author -> Success
+			await expect(caller.deleteCourse(input)).resolves.not.toThrow();
+		});
+
+		it("should throw error if user is not author", async () => {
+			const caller = prepare({
+				isAuthor: false,
+				name: "author1"
+			});
+			const input = { slug: "test-course" };
+
+			// Course exists; user is no author -> TRPCError
+			await expect(caller.deleteCourse(input)).rejects.toThrow(TRPCError);
+		});
+
+		it("should throw error if user is wrong author", async () => {
+			const caller = prepare({
+				isAuthor: true,
+				name: "author3"
+			});
+			const input = { slug: "test-course" };
+
+			// Course exists; user is foreign author -> TRPCError
+			await expect(caller.deleteCourse(input)).rejects.toThrow(TRPCError);
+		});
+
+		it("should throw error if course does not exist", async () => {
+			const caller = prepare({
+				isAuthor: true,
+				name: "author1"
+			});
+			const input = { slug: "non-existing-course" };
+
+			// Course doesn't exists; user is author -> TRPCError
+			await expect(caller.deleteCourse(input)).rejects.toThrow(TRPCError);
+		});
+	});
+});

--- a/libs/data-access/api/src/lib/trpc/routers/course.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/course.router.ts
@@ -288,9 +288,12 @@ export const courseRouter = t.router({
 		}),
 	deleteCourse: authorProcedure
 		.input(z.object({ slug: z.string() }))
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			return database.course.delete({
-				where: { slug: input.slug }
+				where: {
+					slug: input.slug,
+					authors: { some: { username: ctx.user.name } }
+				}
 			});
 		}),
 	findLinkedEntities: authorProcedure

--- a/libs/data-access/api/src/lib/trpc/routers/lesson.router.trpc.spec.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/lesson.router.trpc.spec.ts
@@ -1,0 +1,132 @@
+import { database } from "@self-learning/database";
+import { Context, UserFromSession } from "../context";
+import { t } from "../trpc";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+import { TRPCError } from "@trpc/server";
+import { lessonRouter } from "./lesson.router";
+
+jest.mock("@self-learning/database", () => ({
+	__esModule: true,
+	database: {
+		lesson: {
+			delete: jest.fn()
+		}
+	}
+}));
+
+function prepare(user: Partial<UserFromSession>) {
+	const ctx: Context & { user: UserFromSession } = {
+		user: {
+			id: "user-id",
+			name: "john",
+			role: "USER",
+			isAuthor: false,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false,
+			...user
+		}
+	};
+	const caller = t.createCallerFactory(lessonRouter)(ctx);
+	return { caller, ctx };
+}
+
+describe("tRPC API of Lesson Router", () => {
+	describe("deleteLesson", () => {
+		function assertWhereClause(lessonId: string, author: string) {
+			expect(database.lesson.delete).toHaveBeenCalledTimes(1);
+
+			const whereClause = (database.lesson.delete as jest.Mock).mock.calls[0][0];
+
+			expect(whereClause).toEqual({
+				where: {
+					lessonId,
+					authors: { some: { username: author } }
+				}
+			});
+		}
+		beforeEach(() => {
+			jest.clearAllMocks();
+			(database.lesson.delete as jest.Mock).mockImplementation(({ where }) => {
+				// Require
+				// - lessonId: "test-lesson"
+				// - Authors: "author1" or "author2"
+				if (
+					where.lessonId === "test-lesson" &&
+					(where.authors.some.username === "author1" ||
+						where.authors.some.username === "author2")
+				) {
+					return Promise.resolve({
+						slug: "test-lessonId",
+						authors: [{ username: "author1" }]
+					});
+				} else {
+					throw new PrismaClientKnownRequestError(
+						"No Lesson found for specified where condition",
+						{ code: "P2025", clientVersion: "4.0.0" } // Mocked error code & version
+					);
+				}
+			});
+		});
+
+		it("should delete lesson if user is author", async () => {
+			const { caller, ctx } = prepare({
+				isAuthor: true,
+				name: "author1"
+			});
+			const input = { id: "test-lesson" };
+
+			// Lesson exists; user is author -> Success
+			await expect(caller.deleteLesson(input)).resolves.not.toThrow();
+			assertWhereClause(input.id, ctx.user.name);
+		});
+
+		it("should delete a lesson if user second author", async () => {
+			const { caller, ctx } = prepare({
+				isAuthor: true,
+				name: "author2"
+			});
+			const input = { id: "test-lesson" };
+
+			// Lesson exists; user is author -> Success
+			await expect(caller.deleteLesson(input)).resolves.not.toThrow();
+			assertWhereClause(input.id, ctx.user.name);
+		});
+
+		it("should throw error if user is not author", async () => {
+			const { caller } = prepare({
+				isAuthor: false,
+				name: "author1"
+			});
+			const input = { id: "test-lesson" };
+
+			// Lesson exists; user is no author -> TRPCError
+			await expect(caller.deleteLesson(input)).rejects.toThrow(TRPCError);
+			// Author procedure should prevent the call to database
+			expect(database.lesson.delete).not.toHaveBeenCalled();
+		});
+
+		it("should throw error if user is wrong author", async () => {
+			const { caller, ctx } = prepare({
+				isAuthor: true,
+				name: "author3"
+			});
+			const input = { id: "test-lesson" };
+
+			// Lesson exists; user is foreign author -> TRPCError
+			await expect(caller.deleteLesson(input)).rejects.toThrow();
+			assertWhereClause(input.id, ctx.user.name);
+		});
+
+		it("should throw error if lesson does not exist", async () => {
+			const { caller, ctx } = prepare({
+				isAuthor: true,
+				name: "author1"
+			});
+			const input = { id: "non-existing-lesson" };
+
+			// Lesson doesn't exists; user is author -> TRPCError
+			await expect(caller.deleteLesson(input)).rejects.toThrow();
+			assertWhereClause(input.id, ctx.user.name);
+		});
+	});
+});

--- a/libs/data-access/api/src/lib/trpc/routers/lesson.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/lesson.router.ts
@@ -147,9 +147,12 @@ export const lessonRouter = t.router({
 		}),
 	deleteLesson: authorProcedure
 		.input(z.object({ id: z.string() }))
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			return database.lesson.delete({
-				where: { lessonId: input.id }
+				where: {
+					lessonId: input.id,
+					authors: { some: { username: ctx.user.name } }
+				}
 			});
 		})
 });


### PR DESCRIPTION
Fix: Autoren können nur eigene Lessons/Course löschen

Fügt Testfälle für die beiden tRPC-Funktionen mit hinzu.