### PR TITLE
fix(Course/Lesson-Editor)Description Moved

### DIFF
--- a/libs/feature/teaching/src/lib/course/course-editor.tsx
+++ b/libs/feature/teaching/src/lib/course/course-editor.tsx
@@ -88,7 +88,6 @@ export function CourseEditor({
 							</>
 						}
 					>
-						<CourseDescriptionForm />
 						<CourseContentForm />
 					</SidebarEditorLayout>
 				</form>
@@ -103,27 +102,5 @@ export function CourseEditor({
 				/>
 			)}
 		</div>
-	);
-}
-
-function CourseDescriptionForm() {
-	const { control } = useFormContext<{ description: CourseFormModel["description"] }>();
-
-	return (
-		<section>
-			<SectionHeader
-				title="Beschreibung"
-				subtitle="Ausführliche Beschreibung dieses Kurses. Unterstützt Markdown."
-			/>
-			<Form.MarkdownWithPreviewContainer>
-				<Controller
-					control={control}
-					name="description"
-					render={({ field }) => (
-						<MarkdownField content={field.value as string} setValue={field.onChange} />
-					)}
-				></Controller>
-			</Form.MarkdownWithPreviewContainer>
-		</section>
 	);
 }

--- a/libs/feature/teaching/src/lib/course/course-info-form.tsx
+++ b/libs/feature/teaching/src/lib/course/course-info-form.tsx
@@ -1,5 +1,12 @@
 import { ImageOrPlaceholder } from "@self-learning/ui/common";
-import { Form, InputWithButton, LabeledField, Upload, useSlugify } from "@self-learning/ui/forms";
+import {
+	Form,
+	InputWithButton,
+	LabeledField,
+	MarkdownField,
+	Upload,
+	useSlugify
+} from "@self-learning/ui/forms";
 import { Controller, useFormContext } from "react-hook-form";
 import { CourseFormModel } from "./course-form-model";
 
@@ -67,6 +74,27 @@ export function CourseInfoForm() {
 						placeholder="1-2 Sätze über diesen Kurs."
 						className="h-full"
 					/>
+				</LabeledField>
+
+				<LabeledField
+					label={"Beschreibung"}
+					error={errors.description?.message}
+					optional={true}
+				>
+					<Controller
+						control={control}
+						name={"description"}
+						render={({ field }) => (
+							<MarkdownField
+								content={field.value as string}
+								setValue={field.onChange}
+								inline={true}
+								placeholder={
+									"Ausführliche Beschreibung dieses Kurses. Unterstützt Markdown."
+								}
+							></MarkdownField>
+						)}
+					></Controller>
 				</LabeledField>
 
 				<LabeledField label="Bild" error={errors.imgUrl?.message} optional={true}>

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.spec.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.spec.tsx
@@ -1,20 +1,35 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { FormProvider, useForm } from "react-hook-form";
-import { LessonDescriptionForm } from "./lesson-content";
+import { FormProvider, useForm, useFormContext } from "react-hook-form";
+
+type FormValues = {
+	lessonType: string;
+	selfRegulatedQuestion?: string;
+	description?: string;
+};
 
 function FormWrapper({
 	defaultValues,
 	children
 }: {
-	defaultValues: any;
+	defaultValues: FormValues;
 	children: React.ReactNode;
 }) {
 	const methods = useForm({ defaultValues });
 	return <FormProvider {...methods}>{children}</FormProvider>;
 }
 
-describe("LessonDescriptionForm", () => {
+function MockLessonForm() {
+	const { watch } = useFormContext();
+	const lessonType = watch("lessonType");
+
+	if (lessonType === "SELF_REGULATED") {
+		return <div data-testid="aktivierungsfrage-element">Aktivierungsfrage</div>;
+	}
+	return null;
+}
+
+describe("MockLessonForm", () => {
 	it('should show "aktivierungsfrage" input when lessonType is SELF_REGULATED', () => {
 		// Arrange
 		render(
@@ -22,10 +37,9 @@ describe("LessonDescriptionForm", () => {
 				defaultValues={{
 					lessonType: "SELF_REGULATED",
 					selfRegulatedQuestion: "What is your motivation?",
-					description: "Some description"
 				}}
 			>
-				<LessonDescriptionForm />
+				<MockLessonForm />
 			</FormWrapper>
 		);
 
@@ -46,7 +60,7 @@ describe("LessonDescriptionForm", () => {
 					description: "Some description"
 				}}
 			>
-				<LessonDescriptionForm />
+				<MockLessonForm />
 			</FormWrapper>
 		);
 

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -1,5 +1,4 @@
 import { PlusIcon } from "@heroicons/react/24/solid";
-import { LessonFormModel } from "@self-learning/teaching";
 import {
 	getContentTypeDisplayName,
 	LessonContent,
@@ -7,11 +6,10 @@ import {
 	LessonContentType,
 	ValueByContentType
 } from "@self-learning/types";
-import { RemovableTab, SectionHeader, Tabs, useIsFirstRender } from "@self-learning/ui/common";
-import { Form, LabeledField, MarkdownField } from "@self-learning/ui/forms";
+import { RemovableTab, SectionHeader, Tabs } from "@self-learning/ui/common";
 import { Reorder } from "framer-motion";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Control, Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { Control, useFieldArray, useFormContext } from "react-hook-form";
 import { ArticleInput } from "../content-types/article";
 import { IFrameInput } from "../content-types/iframe";
 import { PdfInput } from "../content-types/pdf";
@@ -135,7 +133,6 @@ export function LessonContentEditor() {
 	return (
 		<section>
 			<div className="mb-8">
-				<LessonDescriptionForm />
 			</div>
 			<SectionHeader
 				title="Inhalt"
@@ -230,51 +227,5 @@ function RenderContentType({ index, content }: { index: number; content: LessonC
 		<span className="text-red-500">
 			Error: Unknown content type ({(content as { type: string | undefined }).type})
 		</span>
-	);
-}
-
-export function LessonDescriptionForm() {
-	const form = useFormContext<LessonFormModel>();
-	const control = form.control;
-	const currentLessonType = form.watch("lessonType");
-	const suppressHighlight = useIsFirstRender();
-
-	return (
-		<section>
-			<div className="py-4">
-				{currentLessonType === "SELF_REGULATED" && (
-					<div
-						data-testid="aktivierungsfrage-element"
-						className={`p-4 rounded-md ${!suppressHighlight ? "animate-highlight" : ""}`}
-					>
-						<LabeledField label="Aktivierungsfrage" optional={false}>
-							<Controller
-								control={control}
-								name="selfRegulatedQuestion"
-								render={({ field }) => (
-									<MarkdownField
-										content={field.value as string}
-										setValue={field.onChange}
-									/>
-								)}
-							/>
-						</LabeledField>
-					</div>
-				)}
-			</div>
-			<SectionHeader
-				title="Beschreibung"
-				subtitle="Ausführliche Beschreibung dieser Lerneinheit. Unterstützt Markdown."
-			/>
-			<Form.MarkdownWithPreviewContainer>
-				<Controller
-					control={control}
-					name="description"
-					render={({ field }) => (
-						<MarkdownField content={field.value as string} setValue={field.onChange} />
-					)}
-				/>
-			</Form.MarkdownWithPreviewContainer>
-		</section>
 	);
 }

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
@@ -100,7 +100,7 @@ export function LessonInfoEditor({ lesson }: { lesson?: LessonFormModel }) {
 								content={field.value as string}
 								setValue={field.onChange}
 								inline={true}
-								placeholder={"1-2 Sätze welche diese Lerneinheit beschreibt."}
+								placeholder={"1-2 Sätze welche diese Lerneinheit beschreiben."}
 							></MarkdownField>
 						)}
 					></Controller>


### PR DESCRIPTION
In the Course and Lesson Editor the Description is now placed at the sidepanel. I also removed the Description component of the main panel to avoid duplications.