### PR TITLE
fix(arrange): add categoryOrder to keep the same order when not randomized

### DIFF
--- a/libs/feature/question-types/src/lib/question-type-registry.tsx
+++ b/libs/feature/question-types/src/lib/question-type-registry.tsx
@@ -199,7 +199,8 @@ export const INITIAL_QUESTION_CONFIGURATION_FUNCTIONS: {
 		...createBaseQuestion(),
 		type: "arrange",
 		items: {},
-		randomizeItems: false
+		randomizeItems: false,
+		categoryOrder: []
 	}),
 	"language-tree": () => ({
 		...createBaseQuestion(),
@@ -259,7 +260,7 @@ export function QuestionAnswerRenderer({
 	}
 
 	if (question.type === "arrange") {
-		return <ArrangeAnswer />;
+		return <ArrangeAnswer order={question.categoryOrder} />;
 	}
 
 	if (question.type === "language-tree") {

--- a/libs/feature/question-types/src/lib/question-types/arrange/component.tsx
+++ b/libs/feature/question-types/src/lib/question-types/arrange/component.tsx
@@ -3,8 +3,15 @@ import { MarkdownViewer } from "@self-learning/ui/forms";
 import { Fragment } from "react";
 import { Feedback } from "../../feedback";
 import { useQuestion } from "../../use-question-hook";
+import { ArrangeItem } from "./schema";
+import { watch } from "fs";
 
-export default function ArrangeQuestion() {
+type ArrangeQuestionProps = {
+	order: string[];
+}
+
+
+export default function ArrangeQuestion({ order = []}: {order: string[]}) {
 	const { answer, setAnswer, evaluation } = useQuestion("arrange");
 
 	return (
@@ -25,7 +32,9 @@ export default function ArrangeQuestion() {
 				}}
 			>
 				<div className="grid auto-rows-fr gap-4 grid-flow-row xl:grid-flow-col">
-					{Object.entries(answer.value).map(([containerId, items]) => (
+					{order
+						.filter(containerId => containerId !== "_init")
+						.map(containerId => (
 						// eslint-disable-next-line react/jsx-no-useless-fragment
 						<Fragment key={containerId}>
 							{containerId === "_init" ? null : (
@@ -45,7 +54,7 @@ export default function ArrangeQuestion() {
 												{...provided.droppableProps}
 												className="flex min-w-fit flex-col gap-4 rounded-lg bg-gray-100 p-4"
 											>
-												{items.map((item, index) => (
+												{answer.value[containerId]?.map((item, index) => (
 													<Draggable
 														key={item.id}
 														draggableId={item.id}

--- a/libs/feature/question-types/src/lib/question-types/arrange/schema.ts
+++ b/libs/feature/question-types/src/lib/question-types/arrange/schema.ts
@@ -11,7 +11,8 @@ export type ArrangeItem = z.infer<typeof itemSchema>;
 export const arrangeQuestionSchema = baseQuestionSchema.extend({
 	type: z.literal("arrange"),
 	items: z.record(z.array(itemSchema)),
-	randomizeItems: z.boolean().optional().default(false)
+	randomizeItems: z.boolean().optional().default(false),
+	categoryOrder: z.array(z.string())
 });
 
 export type ArrangeQuestion = z.infer<typeof arrangeQuestionSchema>;


### PR DESCRIPTION
CategoryOrder was added into the question.type arrange to get easy access from the question object to the categoryOrder.
This prevented changing the datastructure behind it to an array with arrays and is a simpler fix.