### PR TITLE
fix([lessonSlug]) make LessonView in Course reachable again

### DIFF
--- a/apps/site/pages/courses/[courseSlug]/[lessonSlug]/index.tsx
+++ b/apps/site/pages/courses/[courseSlug]/[lessonSlug]/index.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = withTranslations(["common"], async context => 
 		return {
 			props: {
 				...props,
-				course: null,
+				course: props.course,
 				markdown: {
 					...lessonProps
 				}


### PR DESCRIPTION
I passed the course props into getServerSideProps to give the course data needed for the sidebar into the lessonLayout.
Now there is no runtime Error anymore and lesson gets rendered properly.