### PR TITLE
chore(index.d.ts): fix typescript .env type detection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,32 @@
 import NextAuth from "next-auth";
 
-declare var process: {
-	env: {
-		NODE_ENV: "development" | "production";
-		NEXT_PUBLIC_IS_DEMO_INSTANCE: string | undefined;
-		NEXT_PUBLIC_BASE_PATH: string | undefined;
-		NEXT_TRAILING_SLASH: Boolean | undefined;
-		NEXT_PUBLIC_MATOMO_ULR: string | undefined;
-		NEXT_PUBLIC_MATOMO_SITE_ID: string | undefined;
-		DATABASE_URL: string;
-		MINIO_ENDPOINT: string;
-		MINIO_PORT: string;
-		MINIO_USE_SSL: string;
-		MINIO_ACCESS_KEY: string;
-		MINIO_SECRET_KEY: string;
-		MINIO_BUCKET_NAME: string;
-		PISTON_URL: string;
-		KEYCLOAK_ISSUER_URL: string;
-		KEYCLOAK_CLIENT_ID: string;
-		KEYCLOAK_PROVIDER_NAME: string | undefined;
-		NEXTAUTH_URL: string;
-		NEXTAUTH_SECRET: string;
-		APP_VERSION: string;
-	};
-};
+// https://stackoverflow.com/questions/45194598/using-process-env-in-typescript
+declare global {
+	namespace NodeJS {
+		interface ProcessEnv {
+			NODE_ENV: "development" | "production";
+			NEXT_PUBLIC_IS_DEMO_INSTANCE: string | undefined;
+			NEXT_PUBLIC_BASE_PATH: string | undefined;
+			NEXT_TRAILING_SLASH: Boolean | undefined;
+			NEXT_PUBLIC_MATOMO_ULR: string | undefined;
+			NEXT_PUBLIC_MATOMO_SITE_ID: string | undefined;
+			DATABASE_URL: string;
+			MINIO_ENDPOINT: string;
+			MINIO_PORT: string;
+			MINIO_USE_SSL: string;
+			MINIO_ACCESS_KEY: string;
+			MINIO_SECRET_KEY: string;
+			MINIO_BUCKET_NAME: string;
+			PISTON_URL: string;
+			KEYCLOAK_ISSUER_URL: string;
+			KEYCLOAK_CLIENT_ID: string;
+			KEYCLOAK_PROVIDER_NAME: string | undefined;
+			NEXTAUTH_URL: string;
+			NEXTAUTH_SECRET: string;
+			APP_VERSION: string | undefined;
+		}
+	}
+}
 
 declare module "next-auth" {
 	/**


### PR DESCRIPTION
Ref #258

I can not check if fix works directly, as error does not appear for me.
But it seems like typescript detect the type correctly now:

index.d.ts:
![image](https://github.com/user-attachments/assets/374ba8cd-51d0-414c-ad6f-dd02e8e74bcf)

Before:
![image](https://github.com/user-attachments/assets/620b9558-65f3-4fd5-9f85-a343619d7ff6)

After:
![image](https://github.com/user-attachments/assets/afd82b1f-6e67-4411-baff-3331720c12bc)
