### PR TITLE
feat(forms): add questionOrder to quickly change Order of Questions in Json Editor

### DIFF
--- a/apps/site/__tests__/quiz.spec.tsx
+++ b/apps/site/__tests__/quiz.spec.tsx
@@ -51,6 +51,7 @@ const mockQuestions = [
 		type: "multiple-choice"
 	}
 ] as any[];
+const mockQuestionOrder = mockQuestions.map(q => q.questionId);
 
 describe("QuizHeader", () => {
 	beforeEach(() => {
@@ -65,6 +66,7 @@ describe("QuizHeader", () => {
 				questions={mockQuestions}
 				currentIndex={0}
 				goToQuestion={jest.fn()}
+				questionOrder={mockQuestionOrder}
 			/>
 		);
 		await waitFor(() => {
@@ -88,6 +90,7 @@ describe("QuizHeader", () => {
 				questions={mockQuestions}
 				currentIndex={0}
 				goToQuestion={jest.fn()}
+				questionOrder={mockQuestionOrder}
 			/>
 		);
 

--- a/apps/site/pages/courses/[courseSlug]/[lessonSlug]/quiz.tsx
+++ b/apps/site/pages/courses/[courseSlug]/[lessonSlug]/quiz.tsx
@@ -13,7 +13,7 @@ export const getServerSideProps = withAuth<QuestionProps>(async ({ params, local
 
 	const { questionsMd, answersMd, hintsMd, processedQuestions } = await compileQuizMarkdown(quiz);
 	quiz.questions = processedQuestions;
-
+	
 	return {
 		props: {
 			...(await serverSideTranslations(locale ?? "en", ["common"])),

--- a/libs/data-access/database/prisma/migrations/20250624115908_quiz_order/data-migration.ts
+++ b/libs/data-access/database/prisma/migrations/20250624115908_quiz_order/data-migration.ts
@@ -1,0 +1,183 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { DefaultArgs } from "@prisma/client/runtime/library";
+import { z } from "zod";
+
+const prisma = new PrismaClient();
+
+// 2 Data Migrations for Quizzes of Lessons:
+//   1. Add "questionOrder" to Quizzes that do not have it defined.
+//   2. Add "categoryOrder" to "arrange" Quizzes that do not have it defined.
+
+const newQuizSchema = z.object({
+	questions: z.array(
+		z.object({
+			questionId: z.string(),
+			type: z.string()
+		})
+	),
+	questionOrder: z.array(z.string()),
+	config: z.any().nullable()
+});
+
+const newLessonSchema = z.object({
+	slug: z.string(),
+	quiz: newQuizSchema.nullable()
+});
+
+const oldLessonSchema = newLessonSchema.extend({
+	quiz: newQuizSchema
+		.extend({
+			questionOrder: z.undefined()
+		})
+		.nullable()
+});
+
+const oldLessonSchemaWithDefinedQuiz = oldLessonSchema.extend({
+	quiz: newQuizSchema.extend({
+		questionOrder: z.undefined()
+	})
+});
+
+const oldArrangeSchema = z.object({
+	questionId: z.string(),
+	type: z.literal("arrange"),
+	statement: z.string(),
+	withCertainty: z.boolean(),
+	hints: z.array(
+		z.object({
+			hintId: z.string(),
+			content: z.string()
+		})
+	),
+	items: z.record(
+		z.array(
+			z.object({
+				id: z.string(),
+				content: z.string()
+			})
+		)
+	),
+	randomizeItems: z.boolean().optional().default(false)
+});
+
+type OldLesson = z.infer<typeof oldLessonSchema>;
+type OldLessonWQuiz = z.infer<typeof oldLessonSchemaWithDefinedQuiz>;
+
+type OldArrange = z.infer<typeof oldArrangeSchema>;
+
+function isOldLessonWithoutQuestionOrder(lesson: OldLesson): lesson is OldLessonWQuiz {
+	return !!lesson.quiz && lesson.quiz.questionOrder === undefined;
+}
+
+function isOldArrange(quiz: any): quiz is OldArrange {
+	if (oldArrangeSchema.safeParse(quiz).success) {
+		return true;
+	}
+	return false;
+}
+
+async function migrateMissingQuestionOrder(
+	tx: Omit<
+		PrismaClient<Prisma.PrismaClientOptions, never, DefaultArgs>,
+		"$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+	>
+) {
+	const lessons = await tx.lesson.findMany({});
+
+	const promises = lessons
+		// Apply data migration only to lessons with quizzes
+		.filter(lesson => !!lesson.quiz)
+		.map(lesson => {
+			const parsed = oldLessonSchema.safeParse(lesson);
+			if (parsed.success) {
+				return lesson as typeof lesson & OldLesson;
+			} else {
+				return null;
+			}
+		})
+		.map(l => {
+			if (!l) return Promise.resolve();
+
+			const oldQuizData = l.quiz as any;
+			if (isOldLessonWithoutQuestionOrder(l)) {
+				const lessonParsed = l as OldLessonWQuiz;
+				// Extract ordered array of quizzes
+				const questionIds = lessonParsed.quiz.questions.map(q => q.questionId);
+				const questionOrder = questionIds;
+
+				return tx.lesson.update({
+					where: { slug: l.slug },
+					data: {
+						quiz: {
+							...oldQuizData,
+							questionOrder: questionOrder
+						}
+					}
+				});
+			} else {
+				return Promise.resolve();
+			}
+		});
+
+	await Promise.all(promises);
+}
+
+async function migrateMissingCategoryOrder(
+	tx: Omit<
+		PrismaClient<Prisma.PrismaClientOptions, never, DefaultArgs>,
+		"$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+	>
+) {
+	const lessons = await tx.lesson.findMany({});
+
+	const promises = lessons
+		// Apply data migration only to lessons with quizzes
+		.filter(lesson => !!lesson.quiz)
+		.map(lesson => {
+			const parsed = oldLessonSchema.safeParse(lesson);
+			if (parsed.success) {
+				return lesson as typeof lesson & OldLesson;
+			} else {
+				return null;
+			}
+		})
+		.map(l => {
+			if (!l || !l.quiz?.questions.some(q => q.type === "arrange")) return Promise.resolve();
+
+			const oldQuizData = l.quiz as any;
+
+			const migratedQuestions = l.quiz?.questions.map(q => {
+				if (!isOldArrange(q)) return q;
+				return {
+					...q,
+					categoryOrder: Object.keys(q.items)
+				};
+			});
+			const newQuizData = { ...oldQuizData, questions: migratedQuestions };
+
+			return tx.lesson.update({
+				where: { slug: l.slug },
+				data: {
+					quiz: newQuizData
+				}
+			});
+		});
+
+	await Promise.all(promises);
+}
+
+async function main() {
+	try {
+		await prisma.$transaction(async tx => {
+			await migrateMissingQuestionOrder(tx);
+			await migrateMissingCategoryOrder(tx);
+		});
+	} finally {
+		await prisma.$disconnect();
+	}
+}
+
+main().catch(e => {
+	console.error(e);
+	process.exit(1);
+});

--- a/libs/data-access/database/prisma/migrations/20250624115908_quiz_order/migration.sql
+++ b/libs/data-access/database/prisma/migrations/20250624115908_quiz_order/migration.sql
@@ -1,0 +1,1 @@
+-- This is an empty migration.

--- a/libs/feature/quiz/src/lib/quiz.ts
+++ b/libs/feature/quiz/src/lib/quiz.ts
@@ -28,6 +28,7 @@ export const configSchema = z.object({
 
 export const quizSchema = z.object({
 	questions: z.array(quizContentSchema),
+	questionOrder: z.array(z.string()),
 	config: configSchema.nullable()
 });
 

--- a/libs/feature/teaching/src/lib/lesson/forms/quiz-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/quiz-editor.tsx
@@ -17,14 +17,14 @@ import {
 import { LabeledField, MarkdownField } from "@self-learning/ui/forms";
 import { getRandomId } from "@self-learning/util/common";
 import { Reorder } from "framer-motion";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Control, Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { Button } from "@headlessui/react";
 
 type QuizForm = { quiz: Quiz };
 
 export function useQuizEditorForm() {
-	const { control, register, setValue } = useFormContext<QuizForm>();
+	const { control, register, setValue, getValues } = useFormContext<QuizForm>();
 	const {
 		append,
 		remove,
@@ -37,6 +37,16 @@ export function useQuizEditorForm() {
 
 	const [questionIndex, setQuestionIndex] = useState<number>(quiz.length > 0 ? 0 : -1);
 	const currentQuestion = quiz[questionIndex];
+	const questionOrder = useWatch({ control, name: "quiz.questionOrder" });
+	const orderedQuestions = useMemo(() => {
+		if (!questionOrder || questionOrder.length === 0) return quiz;
+
+		const ordered = questionOrder
+			.map(id => quiz.find(q => q.questionId === id))
+			.filter((q): q is NonNullable<typeof q> => !!q);
+
+		return ordered;
+	}, [quiz, questionOrder]);
 
 	function appendQuestion(type: QuestionType["type"]) {
 		const initialConfigFn = INITIAL_QUESTION_CONFIGURATION_FUNCTIONS[type];
@@ -45,17 +55,29 @@ export function useQuizEditorForm() {
 			console.error("No initial configuration function found for question type", type);
 			return;
 		}
-		append(initialConfigFn());
+		const newQuestion = initialConfigFn();
 
+		if (!newQuestion.questionId) {
+			console.error("InitialConfigFn did not return a questionId!", { newQuestion });
+			throw new Error("Invalid question: missing questionId");
+		}
+		append(newQuestion);
+		setValue("quiz.questionOrder", [
+			...(getValues("quiz.questionOrder") ?? []),
+			newQuestion.questionId
+		]);
 		setQuestionIndex(quiz.length);
 	}
 
 	function removeQuestion(index: number) {
 		const confirm = window.confirm("Aufgabe entfernen?");
-
+		const removedId = quiz[index].questionId;
 		if (confirm) {
 			remove(index);
-
+			setValue(
+				"quiz.questionOrder",
+				(getValues("quiz.questionOrder") ?? []).filter(id => id !== removedId)
+			);
 			if (index === questionIndex) {
 				setQuestionIndex(quiz.length - 2); // set to last index or -1 if no questions exist
 			}
@@ -63,6 +85,12 @@ export function useQuizEditorForm() {
 	}
 
 	function setQuiz(questions: QuizForm["quiz"]["questions"]) {
+		setValue("quiz.questions", questions);
+		setValue(
+			"quiz.questionOrder",
+			questions.map(q => q.questionId)
+		);
+
 		const currentQuestionIndex = questions.findIndex(
 			question => question.questionId === currentQuestion?.questionId
 		);
@@ -84,7 +112,8 @@ export function useQuizEditorForm() {
 		setQuestionIndex,
 		currentQuestion,
 		appendQuestion,
-		removeQuestion
+		removeQuestion,
+		orderedQuestions
 	};
 }
 
@@ -97,7 +126,8 @@ export function QuizEditor() {
 		setQuestionIndex,
 		currentQuestion,
 		appendQuestion,
-		removeQuestion
+		removeQuestion,
+		orderedQuestions
 	} = useQuizEditorForm();
 
 	return (
@@ -136,7 +166,7 @@ export function QuizEditor() {
 			{questionIndex >= 0 && (
 				<Reorder.Group values={quiz} onReorder={setQuiz} axis="x" className="w-full">
 					<Tabs selectedIndex={questionIndex} onChange={index => setQuestionIndex(index)}>
-						{quiz.map((value, index) => (
+						{orderedQuestions.map((value, index) => (
 							<Reorder.Item
 								as="div"
 								value={value}

--- a/libs/util/testing/src/lib/mocks.ts
+++ b/libs/util/testing/src/lib/mocks.ts
@@ -164,6 +164,7 @@ lorem ipsum dolor sit amet.`
 			overwrites?.quiz ??
 			({
 				questions: [],
+				questionOrder: [],
 				config: null
 			} satisfies Quiz),
 		meta: Prisma.JsonNull

--- a/libs/util/types/src/lib/lesson.spec.ts
+++ b/libs/util/types/src/lib/lesson.spec.ts
@@ -163,6 +163,7 @@ describe("lessonSchema", () => {
 							withCertainty: false
 						}
 					],
+					questionOrder: ["q1"],
 					config: {
 						hints: {
 							enabled: true,

--- a/libs/util/types/src/lib/lesson.ts
+++ b/libs/util/types/src/lib/lesson.ts
@@ -30,6 +30,7 @@ export const lessonSchema = z.object({
 	quiz: z
 		.object({
 			questions: z.array(z.any()),
+			questionOrder: z.array(z.string()),
 			config: z.any().nullable()
 		})
 		.nullable()


### PR DESCRIPTION
The Quiz object now has an attribute questionOrder, that stores the questionIds in the right order. 
Every time the quiz is used, the questions should be displayed after this order.
In the Json editor it is possible to swap questions arround (switching of questionIds) and the switching of questiontabs in the quizEditor also changes the questionOrder.
This pr closes #395 