### PR TITLE
feat(admin): configuration of llms

### DIFF
--- a/apps/site/pages/admin/index.tsx
+++ b/apps/site/pages/admin/index.tsx
@@ -57,6 +57,11 @@ export default function AdminPage() {
 					imageElement={<CodingSvg />}
 					title="REST API Dokumentation (OpenAPI)"
 				/>
+				<Card
+					href="/admin/llm-config"
+					imageElement={<CodingSvg />}
+					title="LLM Konfiguration"
+				/>
 			</div>
 			<div className="text-center text-sm text-gray-500 mt-8">
 				{`App Version: ${appVersion}`}

--- a/apps/site/pages/admin/llm-config.tsx
+++ b/apps/site/pages/admin/llm-config.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { CenteredSection } from '@self-learning/ui/layouts';
+
+interface LlmConfig {
+  id: string;
+  serverUrl: string;
+  defaultModel: string;
+  hasApiKey: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function LlmConfigPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [config, setConfig] = useState<LlmConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [formData, setFormData] = useState({
+    serverUrl: '',
+    apiKey: '',
+    defaultModel: ''
+  });
+
+  useEffect(() => {
+    if (status === 'loading') return;
+    
+    if (!session || session.user.role !== 'ADMIN') {
+      router.push('/admin');
+      return;
+    }
+
+    fetchConfig();
+  }, [session, status, router]);
+
+  const fetchConfig = async () => {
+    try {
+      const response = await fetch('/api/admin/llm-config');
+      if (response.ok) {
+        const data = await response.json();
+        if (data) {
+          setConfig(data);
+          setFormData({
+            serverUrl: data.serverUrl,
+            apiKey: '', // Don't populate API key for security
+            defaultModel: data.defaultModel
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Failed to fetch configuration:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+
+    try {
+      const method = config ? 'PUT' : 'POST';
+      const response = await fetch('/api/admin/llm-config', {
+        method,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+
+      if (response.ok) {
+        const updatedConfig = await response.json();
+        setConfig(updatedConfig);
+        alert('Configuration saved successfully!');
+      } else {
+        const error = await response.json();
+        alert(`Error: ${error.error}`);
+      }
+    } catch (error) {
+      alert('Failed to save configuration');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+    if (loading) {
+        return <div className="text-center">Loading...</div>;
+  }
+
+  return (
+    <CenteredSection className="bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-6">LLM Server Configuration</h1>
+        
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label htmlFor="serverUrl" className="block text-sm font-medium text-gray-700 mb-2">
+              LLM Server URL *
+            </label>
+            <input
+              type="url"
+              id="serverUrl"
+              name="serverUrl"
+              value={formData.serverUrl}
+              onChange={handleInputChange}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+              placeholder="https://your-llm-server.com/api"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="apiKey" className="block text-sm font-medium text-gray-700 mb-2">
+              API Key (Optional)
+            </label>
+            <input
+              type="password"
+              id="apiKey"
+              name="apiKey"
+              value={formData.apiKey}
+              onChange={handleInputChange}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+              placeholder={config?.hasApiKey ? "••••••••••••••••" : "Enter API key if required"}
+            />
+            {config?.hasApiKey && (
+              <p className="text-sm text-gray-500 mt-1">
+                Leave empty to keep existing API key
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="defaultModel" className="block text-sm font-medium text-gray-700 mb-2">
+              Default Model *
+            </label>
+            <input
+              type="text"
+              id="defaultModel"
+              name="defaultModel"
+              value={formData.defaultModel}
+              onChange={handleInputChange}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500"
+              placeholder="gpt-3.5-turbo, claude-3-sonnet, etc."
+            />
+          </div>
+
+          <div className="flex justify-between items-center">
+            <button
+              type="submit"
+              disabled={saving}
+              className="btn btn-primary"
+            >
+              {saving ? 'Saving...' : config ? 'Update Configuration' : 'Save Configuration'}
+            </button>
+
+            {config && (
+              <div className="text-sm text-gray-500">
+                Last updated: {new Date(config.updatedAt).toLocaleDateString()}
+              </div>
+            )}
+          </div>
+        </form>
+      </div>
+    </CenteredSection>
+  );
+}

--- a/apps/site/pages/api/admin/llm-config.ts
+++ b/apps/site/pages/api/admin/llm-config.ts
@@ -1,0 +1,112 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from 'libs/data-access/api/src/lib/auth/auth';
+import { database } from '@self-learning/database';
+
+interface LlmConfigData {
+  serverUrl: string;
+  apiKey?: string;
+  defaultModel: string;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions);
+  
+  // Check if user is admin
+  if (!session || session.user.role !== 'ADMIN') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  switch (req.method) {
+    case 'GET':
+      return handleGet(res);
+    case 'POST':
+      return handlePost(req, res);
+    case 'PUT':
+      return handlePut(req, res);
+    default:
+      return res.status(405).json({ error: 'Method not allowed' });
+  }
+}
+
+async function handleGet(res: NextApiResponse) {
+  try {
+    const config = await database.llmConfiguration.findFirst({
+      where: { isActive: true }
+    });
+    
+    // Don't expose API key in response
+    if (config) {
+      const { apiKey, ...configWithoutKey } = config;
+      return res.json({ ...configWithoutKey, hasApiKey: !!apiKey });
+    }
+    
+    return res.json(null);
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to fetch configuration' });
+  }
+}
+
+async function handlePost(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { serverUrl, apiKey, defaultModel }: LlmConfigData = req.body;
+    
+    // Validate required fields
+    if (!serverUrl || !defaultModel) {
+      return res.status(400).json({ error: 'Server URL and default model are required' });
+    }
+
+    // Deactivate existing configurations
+    await database.llmConfiguration.updateMany({
+      where: { isActive: true },
+      data: { isActive: false }
+    });
+
+    // Create new configuration
+    const config = await database.llmConfiguration.create({
+      data: {
+        serverUrl,
+        apiKey: apiKey || null,
+        defaultModel,
+        isActive: true
+      }
+    });
+
+    const { apiKey: _, ...configWithoutKey } = config;
+    return res.status(201).json({ ...configWithoutKey, hasApiKey: !!config.apiKey });
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to create configuration' });
+  }
+}
+
+async function handlePut(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { serverUrl, apiKey, defaultModel }: LlmConfigData = req.body;
+    
+    if (!serverUrl || !defaultModel) {
+      return res.status(400).json({ error: 'Server URL and default model are required' });
+    }
+
+    const existingConfig = await database.llmConfiguration.findFirst({
+      where: { isActive: true }
+    });
+
+    if (!existingConfig) {
+      return res.status(404).json({ error: 'No active configuration found' });
+    }
+
+    const updatedConfig = await database.llmConfiguration.update({
+      where: { id: existingConfig.id },
+      data: {
+        serverUrl,
+        apiKey: apiKey || null,
+        defaultModel
+      }
+    });
+
+    const { apiKey: _, ...configWithoutKey } = updatedConfig;
+    return res.json({ ...configWithoutKey, hasApiKey: !!updatedConfig.apiKey });
+  } catch (error) {
+    return res.status(500).json({ error: 'Failed to update configuration' });
+  }
+}

--- a/libs/data-access/database/prisma/schema/schema.prisma
+++ b/libs/data-access/database/prisma/schema/schema.prisma
@@ -266,3 +266,16 @@ model EventLog {
   payload     Json?
   // @@id([userId, createdAt, action]) // todo check if optimization is needed
 }
+
+model LlmConfiguration {
+  id              String   @id @default(cuid())
+  serverUrl       String   @map("server_url")
+  apiKey          String?  @map("api_key")
+  defaultModel    String   @map("default_model")
+  availableModels Json?   @default("[]")
+  isActive        Boolean   @default(true) @map("is_active")
+  createdAt       DateTime  @default(now()) @map("created_at")
+  updatedAt       DateTime  @updatedAt @map("updated_at")
+
+  @@map("llm_configurations")
+}

--- a/libs/util/types/src/lib/llm-config.ts
+++ b/libs/util/types/src/lib/llm-config.ts
@@ -1,0 +1,28 @@
+import { database } from "@self-learning/database";
+
+export interface LlmConfig {
+  serverUrl: string;
+  apiKey?: string;
+  defaultModel: string;
+}
+
+export async function getLlmConfiguration(): Promise<LlmConfig | null> {
+  try {
+    const config = await database.llmConfiguration.findFirst({
+      where: { isActive: true }
+    });
+
+    if (!config) {
+      return null;
+    }
+
+    return {
+      serverUrl: config.serverUrl,
+      apiKey: config.apiKey || undefined,
+      defaultModel: config.defaultModel
+    };
+  } catch (error) {
+    console.error('Failed to fetch LLM configuration:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
Created a configuration page for admins to setup the integration of an LLM server.

### Features

- [ ] Configuration of LLM servers with server url.
- [ ] Mandatory: A LLM server to be used
- [ ] Mandatory: An optional specification of an API key to be used (or none if no key is required)
- [ ] Mandatory: The (default) model to be used
- [ ] Consider for future extension: Selection of further models, which may be selected by end users (teachers)
- [ ] Migrate Database (prisma) extension to safe configured values
- [ ] Administration page as part of /admin (only).

Fixes #390 