### PR TITLE
rf(learning content): format and display 

### DIFF
--- a/libs/data-access/database/src/lib/math/DidacticsOfGeometry.ts
+++ b/libs/data-access/database/src/lib/math/DidacticsOfGeometry.ts
@@ -19,7 +19,17 @@ const ch_Begriffslernen = {
 				createVideo(
 					"https://staging.sse.uni-hildesheim.de:9006/upload/didactics_of_mathematics/01_raeumliche%20Orientierung.mp4",
 					354
-				)
+				),
+				createArticle({
+					mdContent:
+						"# Markdown Text\n\nSome markdown information here about Räumliche Orientierung",
+					estimatedDuration: 30
+				}),
+				createArticle({
+					mdContent:
+						"# Another Markdown Text\n\nSome markdown information here about Räumliche Orientierung",
+					estimatedDuration: 30
+				})
 			],
 			questions: [
 				createMultipleChoice({

--- a/libs/data-access/local-storage/src/lib/local-storage-schema.ts
+++ b/libs/data-access/local-storage/src/lib/local-storage-schema.ts
@@ -1,7 +1,3 @@
-// for build optimization, this should import from @self-learning/types and not from feature libraries
-
-import { LessonContent } from "@self-learning/types";
-
 export interface LocalStorageKeyTypeMap {
 	// Data for testing. Should not be set in production
 	["test_key"]: Date | { test: string } | number | { objDate: Date };
@@ -11,9 +7,6 @@ export interface LocalStorageKeyTypeMap {
 
 	// LearningDiary preference for compact view inside the page viewer
 	["ltb_pageViewer_compactPreference"]: boolean;
-
-	// Preference Setting: What media type is shown as default when open a lesson
-	["user_preferredMediaType"]: LessonContent[number]["type"];
 
 	// Preference Setting: Should the sidebar* be hidden. *Sidebar is a layout component, eg. the playlist area in lessons
 	["user_hideSidebar"]: boolean;

--- a/libs/feature/lesson/src/index.ts
+++ b/libs/feature/lesson/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/lesson-layout";
+export * from "./lib/lesson-layout-context";
 export * from "./lib/use-lesson-context";
 export * from "./lib/lesson-data-access";
 export * from "./lib/lesson-viewer-page";

--- a/libs/feature/lesson/src/lib/get-static-lesson-props.ts
+++ b/libs/feature/lesson/src/lib/get-static-lesson-props.ts
@@ -17,14 +17,15 @@ export async function getStaticLessonProps(lesson: LessonData) {
 		mdSubtitle = await compileMarkdown(lesson.subtitle);
 	}
 
-	const { content: article } = findContentType("article", lesson.content as LessonContent);
+	// Do not touch articles - not used anyway TODO
+	// const { content: article } = findContentType("article", lesson.content as LessonContent);
 
-	if (article) {
-		mdArticle = await compileMarkdown(article.value.content ?? "Kein Inhalt.");
-		// Remove article content to avoid duplication
+	// if (article) {
+	// 	mdArticle = await compileMarkdown(article.value.content ?? "Kein Inhalt.");
+	// 	// Remove article content to avoid duplication
 
-		article.value.content = "(replaced)";
-	}
+	// 	article.value.content = "(replaced)";
+	// }
 
 	// TODO change to check if the lesson is self regulated
 	if (lesson.lessonType === LessonType.SELF_REGULATED) {

--- a/libs/feature/lesson/src/lib/lesson-layout-context.tsx
+++ b/libs/feature/lesson/src/lib/lesson-layout-context.tsx
@@ -1,0 +1,10 @@
+// LessonLayoutContext.tsx
+import { createContext, useContext } from "react";
+
+export type LessonLayoutContextType = {
+	playlistRef?: React.RefObject<HTMLDivElement>;
+};
+
+export const LessonLayoutContext = createContext<LessonLayoutContextType>({});
+
+export const useLessonLayout = () => useContext(LessonLayoutContext);

--- a/libs/feature/lesson/src/lib/lesson-layout.tsx
+++ b/libs/feature/lesson/src/lib/lesson-layout.tsx
@@ -6,8 +6,9 @@ import { Playlist, PlaylistContent, PlaylistLesson } from "@self-learning/ui/les
 import { NextComponentType, NextPageContext } from "next";
 import Head from "next/head";
 import type { ParsedUrlQuery } from "querystring";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { LessonData, getLesson } from "./lesson-data-access";
+import { LessonLayoutContext, LessonLayoutContextType } from "./lesson-layout-context";
 
 export type LessonLayoutProps = {
 	lesson: LessonData;
@@ -106,8 +107,13 @@ function mapToPlaylistContent(
 }
 
 function BaseLessonLayout({ title, playlistArea, children }: BaseLessonLayoutProps) {
+	const playlistRef = useRef<HTMLDivElement>(null);
+
+	const contextValue: LessonLayoutContextType = {
+		playlistRef
+	};
 	return (
-		<>
+		<LessonLayoutContext.Provider value={contextValue}>
 			<Head>
 				<title>{title}</title>
 			</Head>
@@ -118,7 +124,7 @@ function BaseLessonLayout({ title, playlistArea, children }: BaseLessonLayoutPro
 					<div className="w-full pt-8 pb-16">{children}</div>
 				</div>
 			</div>
-		</>
+		</LessonLayoutContext.Provider>
 	);
 }
 

--- a/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
+++ b/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
@@ -3,7 +3,6 @@ import { LessonType } from "@prisma/client";
 import { trpc } from "@self-learning/api-client";
 import { useCourseCompletion, useMarkAsCompleted } from "@self-learning/completion";
 import { getCourse, useLessonContext } from "@self-learning/lesson";
-import { saveToLocalStorage } from "@self-learning/local-storage";
 import { CompiledMarkdown, compileMarkdown } from "@self-learning/markdown";
 import {
 	Article,
@@ -14,7 +13,11 @@ import {
 } from "@self-learning/types";
 import { AuthorsList, LicenseChip, Tab, Tabs } from "@self-learning/ui/common";
 import { LabeledField } from "@self-learning/ui/forms";
-import { MarkdownContainer, useRequiredSession } from "@self-learning/ui/layouts";
+import {
+	DraggableContentSelector,
+	MarkdownContainer,
+	useRequiredSession
+} from "@self-learning/ui/layouts";
 import { PdfViewer, VideoPlayer } from "@self-learning/ui/lesson";
 import { useEventLog } from "@self-learning/util/common";
 import { MDXRemote } from "next-mdx-remote";
@@ -69,6 +72,8 @@ export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 				mdSubtitle={markdown.subtitle}
 			/>
 
+			{course && <MediaTypeSelector lesson={lesson} course={course} />}
+
 			{content.map(c => {
 				console.log(`content type ${c.type}`);
 				switch (c.type) {
@@ -96,13 +101,6 @@ export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 						return <ContentError text={`unsupported content type: ${c.type}`} />;
 				}
 			})}
-
-			<LessonFooter
-				lesson={lesson}
-				course={course}
-				mdDescription={markdown.description}
-				mdSubtitle={markdown.subtitle}
-			/>
 		</article>
 	);
 }
@@ -130,39 +128,6 @@ function ContentError({ text }: { text: string }) {
 }
 function ContentLoader() {
 	return <div className="py-16 text-center">Loading...</div>;
-}
-
-function LessonFooter({
-	course,
-	lesson,
-	mdDescription,
-	mdSubtitle
-}: {
-	course: LessonProps["course"];
-	lesson: LessonProps["lesson"];
-	mdDescription?: CompiledMarkdown | null;
-	mdSubtitle?: CompiledMarkdown | null;
-}) {
-	return (
-		<div className="flex flex-col gap-8">
-			<div className="flex flex-wrap justify-between gap-4">
-				<div className="flex w-full flex-col">
-					<span className="flex flex-wrap-reverse justify-between gap-4">
-						<span className="flex flex-col gap-3">
-							<Authors authors={lesson.authors} />
-						</span>
-						<div className="-mt-3">
-							{!lesson.license ? (
-								<DefaultLicenseLabel />
-							) : (
-								<LicenseLabel license={lesson.license} />
-							)}
-						</div>
-					</span>
-				</div>
-			</div>
-		</div>
-	);
 }
 
 function LessonHeader({
@@ -201,11 +166,18 @@ function LessonHeader({
 							<MDXRemote {...mdSubtitle} />
 						</MarkdownContainer>
 					)}
-					{!isStandalone && (
-						<div className="pt-4">
-							<MediaTypeSelector lesson={lesson} course={course} />
+					<span className="flex flex-wrap-reverse justify-between gap-4">
+						<span className="flex flex-col gap-3">
+							<Authors authors={lesson.authors} />
+						</span>
+						<div className="-mt-3">
+							{!lesson.license ? (
+								<DefaultLicenseLabel />
+							) : (
+								<LicenseLabel license={lesson.license} />
+							)}
 						</div>
-					)}
+					</span>
 				</div>
 			</div>
 

--- a/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
+++ b/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
@@ -30,9 +30,7 @@ import {
 import { LabeledField } from "@self-learning/ui/forms";
 import {
 	DraggableContentOutline,
-	DraggableContentSelector,
 	DraggableContentViewer,
-	DraggableItem,
 	MarkdownContainer,
 	useDraggableContent,
 	useRequiredSession
@@ -252,6 +250,8 @@ export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 		if (openedMedia.removeContent) {
 			openedMedia.removeContent(idx);
 			openedMedia.setActiveIndex(undefined);
+		} else {
+			console.log("Error: in mediaContent remove is disabled!");
 		}
 	};
 
@@ -646,7 +646,7 @@ function SelfRegulatedPreQuestion({
 					onClick={() => {
 						setShowDialog(false);
 					}}
-					disabled={userAnswer.length == 0}
+					disabled={userAnswer.length === 0}
 				>
 					Antwort Speichern
 				</button>

--- a/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
+++ b/libs/feature/lesson/src/lib/lesson-viewer-page.tsx
@@ -1,4 +1,10 @@
-import { CheckCircleIcon, PencilIcon, PlayIcon } from "@heroicons/react/24/solid";
+import {
+	CheckCircleIcon,
+	ChevronDoubleLeftIcon,
+	ChevronDoubleRightIcon,
+	PencilIcon,
+	PlayIcon
+} from "@heroicons/react/24/solid";
 import { LessonType } from "@prisma/client";
 import { trpc } from "@self-learning/api-client";
 import { useCourseCompletion, useMarkAsCompleted } from "@self-learning/completion";
@@ -6,16 +12,29 @@ import { getCourse, useLessonContext } from "@self-learning/lesson";
 import { CompiledMarkdown, compileMarkdown } from "@self-learning/markdown";
 import {
 	Article,
+	CourseContent,
 	getContentTypeDisplayName,
 	LessonContent,
+	LessonContentType,
 	LessonMeta,
 	ResolvedValue
 } from "@self-learning/types";
-import { AuthorsList, LicenseChip, Tab, Tabs } from "@self-learning/ui/common";
+import {
+	AuthorsList,
+	LicenseChip,
+	SectionCard,
+	Tab,
+	Tabs,
+	RemovableTab
+} from "@self-learning/ui/common";
 import { LabeledField } from "@self-learning/ui/forms";
 import {
+	DraggableContentOutline,
 	DraggableContentSelector,
+	DraggableContentViewer,
+	DraggableItem,
 	MarkdownContainer,
+	useDraggableContent,
 	useRequiredSession
 } from "@self-learning/ui/layouts";
 import { PdfViewer, VideoPlayer } from "@self-learning/ui/lesson";
@@ -23,8 +42,10 @@ import { useEventLog } from "@self-learning/util/common";
 import { MDXRemote } from "next-mdx-remote";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 import { LessonData } from "./lesson-data-access";
+import { Button } from "@headlessui/react";
+import { DocumentIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 
 export type LessonProps = {
 	lesson: LessonData;
@@ -36,10 +57,165 @@ export type LessonProps = {
 		subtitle: CompiledMarkdown | null;
 	};
 };
+function ContentTabItem({ item }: { item?: LessonContentType }) {
+	return <span>{item ? item.type : ""}</span>;
+}
+function ContentDisplayItem({
+	item: c,
+	index,
+	lesson,
+	course,
+	addMediaDisplay
+}: {
+	item?: LessonContentType;
+	index?: number;
+	lesson: LessonProps["lesson"];
+	course: LessonProps["course"];
+	addMediaDisplay: (m: LessonContentType, idx: number) => void;
+}) {
+	if (!c || index === undefined) {
+		return <ContentInfo text="Diese Lerneinheit hat keinen Inhalt." />;
+	}
+	switch (c.type) {
+		case "article":
+			return (
+				<SectionCard>
+					<div className="flex flex-col gap-4">
+						<div className="flex items-center gap-2">
+							<DocumentTextIcon className="h-6 w-6 text-primary" />
+							<span className="text-lg font-semibold">Article</span>
+						</div>
+						<LessonArticle article={c} />
+					</div>
+				</SectionCard>
+			);
+		case "video":
+			if (!c.value.url) return <ContentInfo error text="Fehlende Video-URL." />;
+			return (
+				<SectionCard>
+					<div className="flex flex-col gap-4">
+						<div className="flex items-center gap-2">
+							<PlayIcon className="h-6 w-6 text-primary" />
+							<span className="text-lg font-semibold">Video</span>
+						</div>
+						<div className="aspect-video w-full xl:max-h-[75vh]">
+							<VideoPlayer
+								parentLessonId={lesson.lessonId}
+								url={c.value.url}
+								courseId={course?.courseId}
+							/>
+						</div>
+					</div>
+				</SectionCard>
+			);
+		case "pdf":
+			if (!c.value.url) return <ContentInfo error text="missing PDF URL" />;
+			return (
+				<SectionCard>
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<DocumentIcon className="h-6 w-6 text-primary" />
+							<span className="text-lg font-semibold">PDF</span>
+						</div>
+						<Button onClick={() => addMediaDisplay(c, index)} className="btn-secondary">
+							In neuem Tab öffnen
+						</Button>
+					</div>
+				</SectionCard>
+			);
+		default:
+			return <ContentInfo error text={`unsupported content type: ${c?.type}`} />;
+	}
+}
+function LessonDisplay({
+	lesson,
+	course,
+	addMediaDisplay
+}: {
+	lesson: LessonProps["lesson"];
+	course: LessonProps["course"];
+	addMediaDisplay: (m: LessonContentType, idx: number) => void;
+}) {
+	const lessonContent = lesson.content as LessonContent;
+
+	const [targetIndex, setTargetIndex] = useState<number | undefined>(undefined);
+	const ctx = useDraggableContent(lessonContent, false, false);
+
+	return (
+		<>
+			<DraggableContentOutline
+				content={ctx.content}
+				swapContent={ctx.swapContent}
+				activeIndex={ctx.activeIndex}
+				setTargetIndex={setTargetIndex}
+				RenderContent={ContentTabItem}
+			/>
+			<DraggableContentViewer
+				content={ctx.content}
+				setActiveIndex={ctx.setActiveIndex}
+				targetIndex={targetIndex}
+				resetTargetIndex={() => setTargetIndex(undefined)}
+				RenderContent={ContentDisplayItem}
+				renderProps={{ addMediaDisplay, lesson, course }}
+			/>
+		</>
+	);
+}
+
+function MediaDisplay({
+	lesson,
+	course,
+	selectedIndex,
+	openedMedia,
+	addMediaDisplay
+}: {
+	lesson: LessonProps["lesson"];
+	course: LessonProps["course"];
+	selectedIndex?: number;
+	openedMedia: OpenedMediaInfo[];
+	addMediaDisplay: (m: LessonContentType, idx: number) => void;
+}) {
+	if (selectedIndex === undefined) {
+		return <LessonDisplay lesson={lesson} course={course} addMediaDisplay={addMediaDisplay} />;
+	}
+
+	const currentMedia = openedMedia[selectedIndex];
+
+	switch (currentMedia?.type) {
+		case "pdf":
+			if (!currentMedia.value.url) return <ContentInfo error text="missing PDF URL" />;
+			return (
+				<div className="h-[90vh] xl:h-[80vh]">
+					<PdfViewer url={currentMedia.value.url} />
+				</div>
+			);
+		default:
+			return <ContentInfo error text={`unsupported content type: ${currentMedia?.type}`} />;
+	}
+}
+// id is required by Draggable. Content id is required to map this to lesson.content pos
+type OpenedMediaInfo = LessonContentType & { id: number; content_id: number };
+//
+type LessonInfo = { lessonId: string; slug: string; title: string; meta: LessonMeta };
+type LessonNavigationItem = { slug: string; lessonId: string };
+type LessonNavigationData = LessonNavigationItem[];
+function extractNavigationInfo(
+	courseContent: CourseContent,
+	lessons: { [lessonId: string]: LessonInfo }
+): LessonNavigationData {
+	const tmp = courseContent.map(chapter => ({
+		content: chapter.content.map(lesson => {
+			const lessonInfo = lessons[lesson.lessonId] ?? {
+				slug: undefined,
+				lessonId: undefined
+			};
+			return lessonInfo;
+		})
+	}));
+	return tmp.flatMap(chapter => chapter.content);
+}
 export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 	const [showDialog, setShowDialog] = useState(lesson.lessonType === LessonType.SELF_REGULATED);
-
-	const content = lesson.content as LessonContent;
 
 	const { newEvent } = useEventLog();
 	useEffect(() => {
@@ -51,6 +227,33 @@ export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 			payload: undefined
 		});
 	}, [newEvent, lesson.lessonId, course?.courseId]);
+
+	const { data: temp } = course
+		? trpc.course.getContent.useQuery({ slug: course.slug })
+		: { data: undefined };
+	const courseContent = useMemo(
+		() => (!temp ? [] : extractNavigationInfo(temp.content, temp.lessonMap)),
+		[temp]
+	);
+	const EMPTY_INIT: OpenedMediaInfo[] = useMemo(() => [], []);
+	const openedMedia = useDraggableContent(EMPTY_INIT, false, true);
+	const addMediaDisplay = (m: LessonContentType, idx: number) => {
+		const existingIndex = openedMedia.content.findIndex(m => m.content_id === idx);
+		let index;
+		if (existingIndex >= 0) {
+			index = existingIndex;
+		} else {
+			index = openedMedia.content.length; // set index to last element
+			openedMedia.appendContent({ ...m, content_id: idx } as OpenedMediaInfo);
+		}
+		openedMedia.setActiveIndex(index);
+	};
+	const removeMediaTab = (idx: number) => {
+		if (openedMedia.removeContent) {
+			openedMedia.removeContent(idx);
+			openedMedia.setActiveIndex(undefined);
+		}
+	};
 
 	if (showDialog && markdown.preQuestion) {
 		return (
@@ -72,35 +275,24 @@ export function LessonLearnersView({ lesson, course, markdown }: LessonProps) {
 				mdSubtitle={markdown.subtitle}
 			/>
 
-			{course && <MediaTypeSelector lesson={lesson} course={course} />}
+			{/* TODO can be replaced with DraggableContentSelector, make Inhalt default and immutable */}
+			<MediaSelector
+				lesson={lesson}
+				course={course}
+				selectedIndex={openedMedia.activeIndex}
+				setSelectedIndex={openedMedia.setActiveIndex}
+				openedMedia={openedMedia.content}
+				removeMediaTab={removeMediaTab}
+			/>
+			<MediaDisplay
+				addMediaDisplay={addMediaDisplay}
+				openedMedia={openedMedia.content}
+				selectedIndex={openedMedia.activeIndex}
+				lesson={lesson}
+				course={course}
+			/>
 
-			{content.map(c => {
-				console.log(`content type ${c.type}`);
-				switch (c.type) {
-					case "video":
-						if (!c.value.url) return <ContentError text="missing video URL" />;
-						return (
-							<div className="aspect-video w-full xl:max-h-[75vh]">
-								<VideoPlayer
-									parentLessonId={lesson.lessonId}
-									url={c.value.url}
-									courseId={course?.courseId}
-								/>
-							</div>
-						);
-					case "article":
-						return <LessonArticle article={c} />;
-					case "pdf":
-						if (!c.value.url) return <ContentError text="missing PDF URL" />;
-						return (
-							<div className="h-[90vh] xl:h-[80vh]">
-								<PdfViewer url={c.value.url} />
-							</div>
-						);
-					default:
-						return <ContentError text={`unsupported content type: ${c.type}`} />;
-				}
-			})}
+			<LessonNavigation content={courseContent} lesson={lesson} course={course} />
 		</article>
 	);
 }
@@ -113,7 +305,7 @@ function LessonArticle({ article }: { article: Article }) {
 		}
 	}, [article]);
 
-	if (!article.value) return <ContentError text="missing article text" />;
+	if (!article.value) return <ContentInfo error text="missing article text" />;
 	if (!markdown) return <ContentLoader />;
 
 	return (
@@ -123,11 +315,73 @@ function LessonArticle({ article }: { article: Article }) {
 	);
 }
 
-function ContentError({ text }: { text: string }) {
-	return <div className="py-16 text-center text-red-500">Error: {text}</div>;
+function ContentInfo({ text, error }: { text: string; error?: boolean }) {
+	return (
+		<SectionCard>
+			<span className={`text-light text-center ${error && "text-red-500"}`}>
+				{error && "Error: "}
+				{text}
+			</span>
+		</SectionCard>
+	);
 }
 function ContentLoader() {
 	return <div className="py-16 text-center">Loading...</div>;
+}
+
+function LessonNavigation({
+	content,
+	lesson,
+	course
+}: {
+	content: LessonNavigationData;
+	lesson: LessonProps["lesson"];
+	course: LessonProps["course"];
+}) {
+	const router = useRouter();
+	const { previous, next } = useMemo(() => {
+		const lessonIndex = content.findIndex(l => l.lessonId === lesson.lessonId);
+
+		return {
+			previous: lessonIndex > 0 ? content[lessonIndex - 1] : null,
+			next: lessonIndex < content.length - 1 ? content[lessonIndex + 1] : null
+		};
+	}, [content, lesson]);
+
+	function navigateToLesson(lesson: LessonNavigationItem) {
+		if (course) {
+			router.push(`/courses/${course.slug}/${lesson.slug}`);
+		}
+	}
+
+	if (!course) {
+		return <span></span>;
+	}
+
+	return (
+		<span className="flex gap-2 justify-between">
+			<button
+				onClick={() => previous && navigateToLesson(previous)}
+				disabled={!previous}
+				className="rounded-lg bg-white flex items-center gap-4 border border-light-border px-4 py-2 disabled:text-gray-300"
+				title="Vorherige Lerneinheit"
+				data-testid="previousLessonButton"
+			>
+				<ChevronDoubleLeftIcon className="h-5" />
+				Vorherige Lerneinheit
+			</button>
+			<button
+				onClick={() => next && navigateToLesson(next)}
+				disabled={!next}
+				className="rounded-lg bg-white flex items-center gap-4 border border-light-border px-4 py-2 disabled:text-gray-300"
+				title="Nächste Lerneinheit"
+				data-testid="nextLessonButton"
+			>
+				Nächste Lerneinheit
+				<ChevronDoubleRightIcon className="h-5" />
+			</button>
+		</span>
+	);
 }
 
 function LessonHeader({
@@ -323,55 +577,42 @@ function Authors({ authors }: { authors: LessonProps["lesson"]["authors"] }) {
 	);
 }
 
-function MediaTypeSelector({
-	lesson,
-	course
+function MediaSelector({
+	selectedIndex,
+	setSelectedIndex,
+	openedMedia,
+	removeMediaTab
 }: {
 	course?: LessonProps["course"];
 	lesson: LessonProps["lesson"];
+	selectedIndex?: number;
+	setSelectedIndex: (idx?: number) => void;
+	removeMediaTab: (idx: number) => void;
+	openedMedia: OpenedMediaInfo[];
 }) {
-	const lessonContent = lesson.content as LessonContent;
-	// If no content is specified at this time, use video as default (and don't s´display anything)
-	const index = 0; // TODO
-	const [selectedIndex, setSelectedIndex] = useState(index);
-	const router = useRouter();
-
-	function changeMediaType(index: number) {
-		const type = lessonContent[index].type;
-
-		let url = `/lessons/${lesson.slug}?type=${type}`;
-
-		if (course) {
-			url = `/courses/${course.slug}/${lesson.slug}?type=${type}`;
-		}
-
-		router.push(url, undefined, {
-			shallow: true
-		});
-
-		setSelectedIndex(index);
-	}
-
-	useEffect(() => {
-		if (selectedIndex !== index) {
-			setSelectedIndex(index);
-		}
-	}, [index, selectedIndex, setSelectedIndex]);
-
+	// index transform to allow first item to be default
+	const index = selectedIndex !== undefined ? selectedIndex + 1 : 0;
+	// TODO can be replaced with DraggableContentSelector, make Inhalt default and immutable
 	return (
-		<>
-			{lessonContent.length > 1 && (
-				<Tabs selectedIndex={selectedIndex} onChange={changeMediaType}>
-					{lessonContent.map((content, idx) => (
-						<Tab key={idx}>
-							<span data-testid="mediaTypeTab">
-								{getContentTypeDisplayName(content.type)}
-							</span>
-						</Tab>
-					))}
-				</Tabs>
-			)}
-		</>
+		<Tabs
+			selectedIndex={index}
+			// index transform to allow first item to be default
+			onChange={idx => {
+				setSelectedIndex(idx > 0 ? idx - 1 : undefined);
+			}}
+		>
+			<Tab key={0}>
+				<span data-testid="mediaTypeTab-Base">Inhalt</span>
+			</Tab>
+			{openedMedia &&
+				openedMedia.map((content, idx) => (
+					<RemovableTab key={idx + 1} onRemove={() => removeMediaTab(idx)}>
+						<span data-testid="mediaTypeTab">
+							{getContentTypeDisplayName(content.type)}
+						</span>
+					</RemovableTab>
+				))}
+		</Tabs>
 	);
 }
 

--- a/libs/feature/question-types/src/lib/question-types/arrange/component.tsx
+++ b/libs/feature/question-types/src/lib/question-types/arrange/component.tsx
@@ -6,8 +6,8 @@ import { useQuestion } from "../../use-question-hook";
 
 export default function ArrangeQuestion() {
 	const { answer, setAnswer, evaluation, question } = useQuestion("arrange");
-	const  order  = question.categoryOrder
-	
+	const order = question.categoryOrder;
+
 	return (
 		<>
 			<DragDropContext

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon } from "@heroicons/react/24/solid";
+import { Bars3Icon, ChevronDownIcon, PlusIcon } from "@heroicons/react/24/solid";
 import { LessonFormModel } from "@self-learning/teaching";
 import {
 	CONTENT_TYPES,
@@ -11,7 +11,8 @@ import {
 	DropdownMenu,
 	SectionHeader,
 	SectionCard,
-	useIsFirstRender
+	useIsFirstRender,
+	XButton
 } from "@self-learning/ui/common";
 import { Form, LabeledField, MarkdownField } from "@self-learning/ui/forms";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -190,13 +191,34 @@ function LessonContentOutlineHeader({
 }
 
 function ContentOutlineTab({
-	item
+	item,
+	swappable,
+	remove,
+	select,
+	active
 }: {
 	item?: FieldArrayWithId<{ content: LessonContent }, "content", "id">;
+	swappable?: boolean;
+	remove?: () => void;
+	select?: () => void;
+	active?: boolean;
 }) {
 	return (
 		<>
-			{item && getContentTypeDisplayName(item.type)}
+			{item && (
+				<div className="flex gap-2 mb-2 text-nowrap flex-nowrap items-center rounded-lg border border-light-border bg-white text-sm p-2">
+					{swappable && <Bars3Icon className="h-5 text-light" />}
+					<span
+						className={`w-full ${active ? "text-secondary" : "text-light"}`}
+						onClick={select}
+					>
+						{getContentTypeDisplayName(item.type)}
+					</span>
+					{remove && (
+						<XButton onClick={remove} title="Entfernen" className="flex items-center" />
+					)}
+				</div>
+			)}
 			{!item && "Kein Inhalt"}
 		</>
 	);
@@ -209,10 +231,10 @@ export function LessonContentEditor() {
 
 	// Helper to utilize scroll into view
 	const [targetTabIndex, setTargetTabIndex] = useState<number | undefined>(undefined);
+	const [isOutlineOpen, setIsOutlineOpen] = useState(false);
 
 	return (
-		// xl:grid-cols-[1fr_300px]
-		<div className="grid w-full gap-8 lg:grid-cols-[1fr_300px]">
+		<div className="w-full lg:grid lg:grid-cols-[1fr_300px] gap-8">
 			{/* overflow is hidden so the draggable area can scroll */}
 			<div className="w-full overflow-hidden flex flex-col gap-8 mb-8">
 				<div className="">
@@ -227,14 +249,28 @@ export function LessonContentEditor() {
 					RenderContent={RenderContentType}
 				/>
 			</div>
-			<div className="bg-gray-100 w-full h-full border-l">
+			<div
+				className="w-full sticky bottom-0
+				max-h-[35vh] lg:max-h-none 
+				border-t lg:border-t-0 lg:border-l border-l-0 
+			  lg:bg-white bg-gray-100 
+				shadow-[0_-6px_6px_-4px_rgba(0,0,0,0.1)] lg:shadow-none"
+			>
 				<div
-					className="fixed z-4 overflow-y-auto 
-				bottom-0 left-0 right-0 lg:top-28
-				lg:left-auto lg:w-72 lg:max-h-none lg:h-auto "
+					className="sticky z-4 overflow-y-auto 
+				bottom-0 lg:top-16 lg:max-h-none max-h-[35vh]
+				lg:left-auto lg:h-auto pl-8 pr-4"
 				>
-					<h2 className="text-xl text-center w-max ml-4 my-2">Inhalt</h2>
-					<div className="ml-6">
+					<h2
+						className="flex gap-4 text-xl text-center w-max my-4 cursor-pointer"
+						onClick={() => setIsOutlineOpen(prev => !prev)}
+					>
+						<ChevronDownIcon
+							className={`w-5 h-5 transition-transform duration-200 ${isOutlineOpen ? "rotate-0" : "-rotate-90"} lg:hidden`}
+						/>
+						Inhalt
+					</h2>
+					<div className={`${isOutlineOpen ? "" : "hidden"} lg:block`}>
 						<DraggableContentOutline
 							content={content}
 							swapContent={swapContent}

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -156,11 +156,13 @@ function LessonContentViewer({
 	content,
 	setActiveContentIndex,
 	targetIndex, // separate from contentIndex to avoid circle dependency
+	resetTargetIndex,
 	emptyMessage
 }: {
 	content: LessonContent;
 	setActiveContentIndex: (idx: number | undefined) => void;
 	targetIndex: number | undefined;
+	resetTargetIndex: () => void;
 	emptyMessage: string;
 }) {
 	const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -172,6 +174,7 @@ function LessonContentViewer({
 				behavior: "smooth",
 				block: "start"
 			});
+			resetTargetIndex();
 		}
 	}, [targetIndex]); // Deliberately avoid update on content to avoid scroll on delete, on swap, .... Allow only on click
 	// Detect active element
@@ -239,7 +242,7 @@ function LessonContentViewer({
 					}}
 					// Add a data attribute to easily retrieve the index in the Intersection Observer callback
 					data-content-index={index}
-					// offset by height of the website header
+					// Scroll positioning fix because of website header
 					className="scroll-mt-16"
 				>
 					<RenderContentType index={index} content={item} />
@@ -310,6 +313,7 @@ function ContentOutline({
 	);
 }
 
+// horizontal
 function LessonContentOutline({
 	content,
 	swapContent,
@@ -432,7 +436,7 @@ export function LessonContentEditor() {
 
 	return (
 		// xl:grid-cols-[1fr_300px]
-		<div className="grid h-full w-full gap-8">
+		<div className="grid w-full gap-8">
 			{/* overflow is hidden so the draggable area can scroll */}
 			<div className="w-full overflow-hidden flex flex-col gap-8">
 				<div className="">
@@ -454,6 +458,7 @@ export function LessonContentEditor() {
 				<LessonContentViewer
 					content={content}
 					targetIndex={targetTabIndex}
+					resetTargetIndex={() => setTargetTabIndex(undefined)} // cheaky way to prevent scroll on update behavior (and more)
 					setActiveContentIndex={setContentTabIndex}
 					emptyMessage="Diese Lerneinheit hat noch keinen Inhalt."
 				/>

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -7,15 +7,26 @@ import {
 	LessonContentType,
 	ValueByContentType
 } from "@self-learning/types";
-import { RemovableTab, SectionHeader, Tabs, useIsFirstRender } from "@self-learning/ui/common";
+import {
+	DropdownMenu,
+	RemovableTab,
+	SectionHeader,
+	Tab,
+	Tabs,
+	useIsFirstRender,
+	XButton
+} from "@self-learning/ui/common";
 import { Form, LabeledField, MarkdownField } from "@self-learning/ui/forms";
 import { Reorder } from "framer-motion";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Control, Controller, useFieldArray, useFormContext } from "react-hook-form";
 import { ArticleInput } from "../content-types/article";
 import { IFrameInput } from "../content-types/iframe";
 import { PdfInput } from "../content-types/pdf";
 import { VideoInput } from "../content-types/video";
+import { Button } from "@headlessui/react";
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
+import { Bars3Icon } from "@heroicons/react/24/outline";
 
 export type SetValueFn = <CType extends LessonContentType["type"]>(
 	type: CType,
@@ -23,24 +34,11 @@ export type SetValueFn = <CType extends LessonContentType["type"]>(
 	index: number
 ) => void;
 
-function useContentTypeUsage(content: LessonContent) {
-	const typesWithUsage = useMemo(() => {
-		const possibleTypes: { [contentType in LessonContentType["type"]]?: boolean } = {};
-
-		for (const c of content) {
-			possibleTypes[c.type] = true;
-		}
-
-		return possibleTypes;
-	}, [content]);
-
-	return typesWithUsage;
-}
-
 export function useLessonContentEditor(control: Control<{ content: LessonContent }>) {
 	const {
 		append,
 		remove,
+		swap,
 		replace: setContent,
 		fields: content
 	} = useFieldArray<{ content: LessonContent }>({
@@ -48,9 +46,31 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 		control
 	});
 
-	const [contentTabIndex, setContentTabIndex] = useState<number | undefined>(
-		content.length > 0 ? 0 : undefined
-	);
+	const [contentTabIndex, setContentTabIndex] = useState<number | undefined>(undefined);
+
+	// check content ids on mount (it will double trigger )
+	const didContextInit = useRef(false);
+	useEffect(() => {
+		// prevent repetition
+		if (didContextInit.current || content.length === 0) return;
+		// do content indexing
+		setContent(
+			content.map((item, index) => ({
+				...item,
+				meta: {
+					...item.meta,
+					id: (index + 1).toString()
+				}
+			})) as LessonContent
+		);
+		//
+		didContextInit.current = true;
+		//
+	}, [content, setContent]);
+	const idCounter = useRef(content.length + 1);
+	function getNextId(type: LessonContentType["type"]) {
+		return (idCounter.current++).toString();
+	}
 
 	useEffect(() => {
 		if (content.length === 0) {
@@ -62,24 +82,31 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 		}
 	}, [contentTabIndex, content]);
 
-	const typesWithUsage = useContentTypeUsage(content);
-
 	function addContent(type: LessonContentType["type"]) {
 		const addActions: { [contentType in LessonContentType["type"]]: () => void } = {
-			video: () => append({ type: "video", value: { url: "" }, meta: { duration: 0 } }),
+			video: () =>
+				append({
+					type: "video",
+					value: { url: "" },
+					meta: { duration: 0, id: getNextId(type) }
+				}),
 			article: () =>
-				append({ type: "article", value: { content: "" }, meta: { estimatedDuration: 0 } }),
+				append({
+					type: "article",
+					value: { content: "" },
+					meta: { estimatedDuration: 0, id: getNextId(type) }
+				}),
 			pdf: () =>
 				append({
 					type: "pdf",
 					value: { url: "" },
-					meta: { estimatedDuration: 0 }
+					meta: { estimatedDuration: 0, id: getNextId(type) }
 				}),
 			iframe: () =>
 				append({
 					type: "iframe",
 					value: { url: "" },
-					meta: { estimatedDuration: 0 }
+					meta: { estimatedDuration: 0, id: getNextId(type) }
 				})
 		};
 
@@ -93,7 +120,12 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 
 		fn();
 
-		setContentTabIndex(content.length); // Select the newly created tab
+		// Do not need it as scroll will automatically set current index
+		// setContentTabIndex(content.length); // Select the newly created tab
+	}
+
+	function swapContent(indexSrc: number, indexDest: number) {
+		swap(indexSrc, indexDest);
 	}
 
 	const removeContent = useCallback(
@@ -109,103 +141,324 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 
 	return {
 		content,
+		swapContent,
 		addContent,
 		removeContent,
 		setContent,
 		contentTabIndex,
-		typesWithUsage,
 		setContentTabIndex
 	};
 }
 
 const contentTypes: LessonContentMediaType[] = ["video", "article", "pdf", "iframe"];
 
-export function LessonContentEditor() {
-	const { control } = useFormContext<{ content: LessonContent }>();
-	const {
-		content,
-		addContent,
-		removeContent,
-		setContent,
-		contentTabIndex,
-		setContentTabIndex,
-		typesWithUsage
-	} = useLessonContentEditor(control);
+function LessonContentViewer({
+	content,
+	setActiveContentIndex,
+	targetIndex, // separate from contentIndex to avoid circle dependency
+	emptyMessage
+}: {
+	content: LessonContent;
+	setActiveContentIndex: (idx: number | undefined) => void;
+	targetIndex: number | undefined;
+	emptyMessage: string;
+}) {
+	const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
+	const visibleItemsRef = useRef<Set<number>>(new Set());
+	// scroll into selected
+	useEffect(() => {
+		if (targetIndex !== undefined && content[targetIndex] && contentRefs.current[targetIndex]) {
+			contentRefs.current[targetIndex].scrollIntoView({
+				behavior: "smooth",
+				block: "start"
+			});
+		}
+	}, [targetIndex]); // Deliberately avoid update on content to avoid scroll on delete, on swap, .... Allow only on click
+	// Detect active element
+	const calculateMinVisibleIndex = () => {
+		if (visibleItemsRef.current.size === 0) return undefined;
+		let min: number | undefined;
+		for (const idx of visibleItemsRef.current) {
+			if (min === undefined || idx < min) min = idx;
+		}
+		return min;
+	};
+	useEffect(() => {
+		console.log("Hello");
+		const observer = new IntersectionObserver(
+			entries => {
+				entries.forEach(entry => {
+					const indexStr = (entry.target as HTMLElement).dataset?.["contentIndex"];
+					if (indexStr !== undefined) {
+						const index = parseInt(indexStr, 10);
+						if (entry.isIntersecting) {
+							visibleItemsRef.current.add(index);
+						} else {
+							visibleItemsRef.current.delete(index);
+						}
+					}
+				});
+				const newActiveIndex = calculateMinVisibleIndex();
+				setActiveContentIndex(newActiveIndex); // React ignores same index update
+			},
+			{
+				root: null,
+				rootMargin: "0px",
+				threshold: 0.1
+			}
+		);
+
+		contentRefs.current.forEach(ref => {
+			if (ref) {
+				observer.observe(ref);
+			}
+		});
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [content, setActiveContentIndex]);
+
+	if (!content || content.length === 0) {
+		return (
+			<section>
+				<div className="rounded-lg border border-light-border bg-white py-80 text-center text-light">
+					{emptyMessage}
+				</div>
+			</section>
+		);
+	}
 
 	return (
-		<section>
-			<div className="mb-8">
-				<LessonDescriptionForm />
-			</div>
-			<SectionHeader
-				title="Inhalt"
-				subtitle="Inhalt, der zur Wissensvermittlung genutzt werden soll. Wenn mehrere Elemente
-					angelegt werden, kann der Student selber entscheiden, welches Medium angezeigt
-					werden soll."
-			/>
-
-			<div className="flex gap-4 text-sm">
-				{contentTypes.map(contentType => (
-					<AddButton
-						key={contentType}
-						contentType={contentType}
-						disabled={typesWithUsage[contentType] === true}
-						addContent={addContent}
-					/>
-				))}
-			</div>
-
-			<div className="mb-8 mt-4 flex gap-4">
-				{content.length > 0 && (
-					<Reorder.Group
-						className="w-full"
-						axis="x"
-						values={content}
-						onReorder={setContent}
-					>
-						<Tabs selectedIndex={contentTabIndex} onChange={setContentTabIndex}>
-							{content.map((value, index) => (
-								<Reorder.Item as="div" key={value.id} value={value}>
-									<RemovableTab onRemove={() => removeContent(index)}>
-										{getContentTypeDisplayName(value.type)}
-									</RemovableTab>
-								</Reorder.Item>
-							))}
-						</Tabs>
-					</Reorder.Group>
-				)}
-			</div>
-
-			{contentTabIndex !== undefined && content[contentTabIndex] ? (
-				<RenderContentType index={contentTabIndex} content={content[contentTabIndex]} />
-			) : (
-				<div className="rounded-lg border border-light-border bg-white py-80 text-center text-light">
-					Diese Lerneinheit hat noch keinen Inhalt.
+		<section className="flex flex-col gap-4">
+			{content.map((item, index) => (
+				<div
+					key={item.meta.id}
+					ref={el => {
+						contentRefs.current[index] = el;
+					}}
+					// Add a data attribute to easily retrieve the index in the Intersection Observer callback
+					data-content-index={index}
+					// offset by height of the website header
+					className="scroll-mt-16"
+				>
+					<RenderContentType index={index} content={item} />
 				</div>
-			)}
+			))}
 		</section>
 	);
 }
 
-function AddButton({
-	contentType,
-	addContent,
-	disabled
+function ContentOutline({
+	content,
+	swapContent,
+	removeContent,
+	contentIndex,
+	selectContent
 }: {
-	contentType: LessonContentMediaType;
-	addContent: (t: LessonContentMediaType) => void;
-	disabled: boolean;
+	content: { id: string; value: string }[];
+	swapContent: (src: number, dest: number) => void;
+	removeContent?: (idx: number) => void;
+	contentIndex: number | undefined;
+	selectContent: (idx: number) => void; // separate from contentIndex to avoid circle dependency
 }) {
 	return (
-		<button
-			type="button"
-			className="btn-primary w-fit"
-			onClick={() => addContent(contentType)}
-			disabled={disabled}
+		<DragDropContext
+			onDragEnd={result => {
+				if (result.reason !== "DROP" || !result.destination) return;
+				swapContent(result.source.index, result.destination.index);
+			}}
 		>
-			<PlusIcon className="icon h-5" />
-			<span>{getContentTypeDisplayName(contentType)} hinzufügen</span>
-		</button>
+			<Droppable droppableId="droppable" direction="vertical">
+				{provided => (
+					<div
+						ref={provided.innerRef}
+						{...provided.droppableProps}
+						className="overflow-y-auto"
+					>
+						<div className="flex flex-col flex-no-wrap gap-4 min-w-max">
+							{content.map((item, index) => (
+								<Draggable key={item.id} draggableId={item.id} index={index}>
+									{provided => (
+										<div
+											ref={provided.innerRef}
+											{...provided.draggableProps}
+											{...provided.dragHandleProps}
+											className={`flex gap-5 text-nowrap flex-nowrap items-center ${contentIndex === index ? "text-secondary" : "text-light"}`}
+										>
+											<Bars3Icon className="h-5 text-light" />
+											<span onClick={() => selectContent(index)}>
+												{item.value}
+											</span>
+											{removeContent && (
+												<XButton
+													onClick={() => removeContent(index)}
+													title="Entfernen"
+													className="flex items-center"
+												/>
+											)}
+										</div>
+									)}
+								</Draggable>
+							))}
+						</div>
+						{provided.placeholder}
+					</div>
+				)}
+			</Droppable>
+		</DragDropContext>
+	);
+}
+
+function LessonContentOutline({
+	content,
+	swapContent,
+	removeContent,
+	contentIndex,
+	selectContentIndex
+}: {
+	content: { id: string; value: string }[];
+	swapContent: (src: number, dest: number) => void;
+	removeContent?: (idx: number) => void;
+	contentIndex: number | undefined;
+	selectContentIndex: (idx: number) => void;
+}) {
+	return (
+		<DragDropContext
+			onDragEnd={result => {
+				if (result.reason !== "DROP" || !result.destination) return;
+				swapContent(result.source.index, result.destination.index);
+			}}
+		>
+			<Droppable droppableId="droppable" direction="horizontal">
+				{provided => (
+					<div
+						ref={provided.innerRef}
+						{...provided.droppableProps}
+						className="overflow-auto"
+					>
+						<Tabs selectedIndex={contentIndex} onChange={selectContentIndex}>
+							<div className="flex flex-no-wrap gap-4 min-w-max">
+								{content.map((item, index) => (
+									<Draggable key={item.id} draggableId={item.id} index={index}>
+										{provided => (
+											<div
+												ref={provided.innerRef}
+												{...provided.draggableProps}
+												{...provided.dragHandleProps}
+											>
+												{removeContent && (
+													<RemovableTab
+														onRemove={() => removeContent(index)}
+													>
+														<div className="flex gap-5 items-center">
+															<Bars3Icon className="h-5 text-light" />
+															{item.value}
+														</div>
+													</RemovableTab>
+												)}
+												{!removeContent && (
+													<Tab>
+														<div className="flex gap-5 items-center">
+															<Bars3Icon className="h-5 text-light" />
+															{item.value}
+														</div>
+													</Tab>
+												)}
+											</div>
+										)}
+									</Draggable>
+								))}
+							</div>
+						</Tabs>
+						{provided.placeholder}
+					</div>
+				)}
+			</Droppable>
+		</DragDropContext>
+	);
+}
+
+function LessonContentOutlineHeader({
+	addContent
+}: {
+	addContent: (type: LessonContentType["type"]) => void;
+}) {
+	return (
+		<section>
+			<SectionHeader
+				title="Inhalt"
+				subtitle="Inhalt, der zur Wissensvermittlung genutzt werden soll. "
+				button={
+					<div className="flex gap-4 text-sm">
+						<DropdownMenu
+							title="Inhalt hinzufügen"
+							button={
+								<div className="btn-primary">
+									<PlusIcon className="icon h-5" />
+									<span className="font-semibold text-white">
+										Inhalt hinzufügen
+									</span>
+								</div>
+							}
+						>
+							{contentTypes.map(contentType => (
+								<Button
+									key={contentType}
+									type={"button"}
+									title="Inhaltstyp Hinzufügen"
+									className={"w-full text-left px-3 py-1"}
+									onClick={() => addContent(contentType)}
+								>
+									{getContentTypeDisplayName(contentType)}
+								</Button>
+							))}
+						</DropdownMenu>
+					</div>
+				}
+			/>
+			<div className="mb-8 mt-4"></div>
+		</section>
+	);
+}
+
+export function LessonContentEditor() {
+	const { control } = useFormContext<{ content: LessonContent }>();
+	const { content, addContent, removeContent, swapContent, contentTabIndex, setContentTabIndex } =
+		useLessonContentEditor(control);
+
+	// Helper to utilize scroll into view
+	const [targetTabIndex, setTargetTabIndex] = useState<number | undefined>(undefined);
+
+	return (
+		// xl:grid-cols-[1fr_300px]
+		<div className="grid h-full w-full gap-8">
+			{/* overflow is hidden so the draggable area can scroll */}
+			<div className="w-full overflow-hidden flex flex-col gap-8">
+				<div className="">
+					<LessonDescriptionForm />
+				</div>
+				<LessonContentOutlineHeader addContent={addContent} />
+				<div className="max-w-full overflow-x-auto">
+					<ContentOutline
+						content={content.map(c => ({
+							id: c.meta.id,
+							value: getContentTypeDisplayName(c.type)
+						}))}
+						swapContent={swapContent}
+						removeContent={removeContent}
+						contentIndex={contentTabIndex}
+						selectContent={setTargetTabIndex}
+					/>
+				</div>
+				<LessonContentViewer
+					content={content}
+					targetIndex={targetTabIndex}
+					setActiveContentIndex={setContentTabIndex}
+					emptyMessage="Diese Lerneinheit hat noch keinen Inhalt."
+				/>
+			</div>
+		</div>
 	);
 }
 
@@ -241,27 +494,25 @@ export function LessonDescriptionForm() {
 
 	return (
 		<section>
-			<div className="py-4">
-				{currentLessonType === "SELF_REGULATED" && (
-					<div
-						data-testid="aktivierungsfrage-element"
-						className={`p-4 rounded-md ${!suppressHighlight ? "animate-highlight" : ""}`}
-					>
-						<LabeledField label="Aktivierungsfrage" optional={false}>
-							<Controller
-								control={control}
-								name="selfRegulatedQuestion"
-								render={({ field }) => (
-									<MarkdownField
-										content={field.value as string}
-										setValue={field.onChange}
-									/>
-								)}
-							/>
-						</LabeledField>
-					</div>
-				)}
-			</div>
+			{currentLessonType === "SELF_REGULATED" && (
+				<div
+					data-testid="aktivierungsfrage-element"
+					className={`pt-4 rounded-md ${!suppressHighlight ? "animate-highlight" : ""}`}
+				>
+					<LabeledField label="Aktivierungsfrage" optional={false}>
+						<Controller
+							control={control}
+							name="selfRegulatedQuestion"
+							render={({ field }) => (
+								<MarkdownField
+									content={field.value as string}
+									setValue={field.onChange}
+								/>
+							)}
+						/>
+					</LabeledField>
+				</div>
+			)}
 			<SectionHeader
 				title="Beschreibung"
 				subtitle="Ausführliche Beschreibung dieser Lerneinheit. Unterstützt Markdown."

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -68,10 +68,6 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 		didContextInit.current = true;
 		//
 	}, [content, setContent]);
-	const idCounter = useRef(content.length + 1);
-	function getNextId(type: LessonContentType["type"]) {
-		return (idCounter.current++).toString();
-	}
 
 	useEffect(() => {
 		if (content.length === 0) {
@@ -89,25 +85,25 @@ export function useLessonContentEditor(control: Control<{ content: LessonContent
 				append({
 					type: "video",
 					value: { url: "" },
-					meta: { duration: 0, id: getNextId(type) }
+					meta: { duration: 0 }
 				}),
 			article: () =>
 				append({
 					type: "article",
 					value: { content: "" },
-					meta: { estimatedDuration: 0, id: getNextId(type) }
+					meta: { estimatedDuration: 0 }
 				}),
 			pdf: () =>
 				append({
 					type: "pdf",
 					value: { url: "" },
-					meta: { estimatedDuration: 0, id: getNextId(type) }
+					meta: { estimatedDuration: 0 }
 				}),
 			iframe: () =>
 				append({
 					type: "iframe",
 					value: { url: "" },
-					meta: { estimatedDuration: 0, id: getNextId(type) }
+					meta: { estimatedDuration: 0 }
 				})
 		};
 

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-content.tsx
@@ -235,11 +235,8 @@ export function LessonContentEditor() {
 
 	return (
 		<div className="w-full lg:grid lg:grid-cols-[1fr_300px] gap-8">
-			{/* overflow is hidden so the draggable area can scroll */}
 			<div className="w-full overflow-hidden flex flex-col gap-8 mb-8">
-				<div className="">
-					<LessonDescriptionForm />
-				</div>
+				<LessonDescriptionForm />
 				<LessonContentOutlineHeader addContent={addContent} />
 				<DraggableContentViewer
 					content={content}

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
@@ -16,7 +16,7 @@ import { lessonSchema } from "@self-learning/types";
 import { GreyBoarderButton } from "@self-learning/ui/common";
 import { LessonSkillManager } from "./lesson-skill-manager";
 
-export function LessonInfoEditor({ lesson }: { lesson?: LessonFormModel }) {
+export function LessonInfoEditor() {
 	const form = useFormContext<LessonFormModel>();
 	const {
 		register,
@@ -28,12 +28,6 @@ export function LessonInfoEditor({ lesson }: { lesson?: LessonFormModel }) {
 
 	return (
 		<Form.SidebarSection>
-			<div>
-				<span className="font-semibold text-secondary">Lerneinheit editieren</span>
-
-				<h1 className="text-2xl">{lesson?.title}</h1>
-			</div>
-
 			<Form.SidebarSectionTitle
 				title="Daten"
 				subtitle="Informationen über diese Lerneinheit"

--- a/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
+++ b/libs/feature/teaching/src/lib/lesson/forms/lesson-info.tsx
@@ -62,7 +62,11 @@ export function LessonInfoEditor({ lesson }: { lesson?: LessonFormModel }) {
 							/>
 						}
 						button={
-							<GreyBoarderButton type="button" onClick={slugifyField} title={"Generiere Slug"}>
+							<GreyBoarderButton
+								type="button"
+								onClick={slugifyField}
+								title={"Generiere Slug"}
+							>
 								<span className={"text-gray-600"}>Generieren</span>
 							</GreyBoarderButton>
 						}

--- a/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
@@ -95,10 +95,10 @@ export function LessonEditor({
 			<form
 				id="lessonform"
 				onSubmit={form.handleSubmit(onSubmit, console.log)}
-				className="flex h-full flex-col overflow-hidden"
+				className="flex flex-col"
 			>
-				<div className="flex h-full overflow-y-auto overflow-x-hidden">
-					<div className="grid h-full w-full gap-8 xl:grid-cols-[500px_1fr] overflow-hidden">
+				<div className="flex overflow-x-hidden">
+					<div className="grid w-full gap-8 xl:grid-cols-[500px_1fr]">
 						{/* TODO here a proper sidebar must be implemented */}
 						{/* TODO very annoying that LessonInfoEditor has mr-3 */}
 						<div className="border-b xl:border-b-0 xl:border-r pr-3">

--- a/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
@@ -54,7 +54,6 @@ export async function onLessonEditorSubmit(
 	}) => Promise<{ title: string }>,
 	lesson?: LessonFormModel
 ) {
-	console.log("JKHFHUIHUIYIUHHIUUHOOUHIJIOUH");
 	try {
 		if (lesson) {
 			const result = await editLessonAsync({

--- a/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
@@ -98,10 +98,14 @@ export function LessonEditor({
 				className="flex h-full flex-col overflow-hidden"
 			>
 				<div className="flex h-full overflow-y-auto overflow-x-hidden">
-					<div className="grid h-full gap-8 xl:grid-cols-[500px_1fr]">
-						<LessonInfoEditor lesson={initialLesson} />
+					<div className="grid h-full w-full gap-8 xl:grid-cols-[500px_1fr] overflow-hidden">
+						{/* TODO here a proper sidebar must be implemented */}
+						{/* TODO very annoying that LessonInfoEditor has mr-3 */}
+						<div className="border-b xl:border-b-0 xl:border-r pr-3">
+							<LessonInfoEditor lesson={initialLesson} />
+						</div>
 
-						<div>
+						<div className="px-3">
 							<Tabs selectedIndex={selectedTab} onChange={v => setSelectedTab(v)}>
 								<Tab>Lerninhalt</Tab>
 								<Tab>Lernkontrolle</Tab>

--- a/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
@@ -1,7 +1,14 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createEmptyLesson, lessonSchema } from "@self-learning/types";
-import { DialogActions, OnDialogCloseFn, showToast, Tab, Tabs } from "@self-learning/ui/common";
+import {
+	DialogActions,
+	GreyBoarderButton,
+	OnDialogCloseFn,
+	showToast,
+	Tab,
+	Tabs
+} from "@self-learning/ui/common";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { LessonContentEditor } from "./forms/lesson-content";
@@ -98,40 +105,32 @@ export function LessonEditor({
 				onSubmit={form.handleSubmit(onSubmit, error => {
 					console.log("EEE", error);
 				})}
-				className="flex flex-col"
+				className="flex flex-col w-full max-w-screen-xl mx-auto px-4"
 			>
-				<div className="flex overflow-x-hidden">
-					<div className="grid w-full gap-8 xl:grid-cols-[500px_1fr]">
-						{/* TODO here a proper sidebar must be implemented */}
-						{/* TODO very annoying that LessonInfoEditor has mr-3 */}
-						<div className="border-b xl:border-b-0 xl:border-r pr-3">
-							<LessonInfoEditor lesson={initialLesson} />
-						</div>
-
-						<div className="pl-3">
-							<Tabs selectedIndex={selectedTab} onChange={v => setSelectedTab(v)}>
-								<Tab>Lerninhalt</Tab>
-								<Tab>Lernkontrolle</Tab>
-							</Tabs>
-							{selectedTab === 0 && <LessonContentEditor />}
-							{selectedTab === 1 && <QuizEditor />}
-						</div>
+				<div className="flex justify-between mb-8">
+					<div className="flex flex-col gap-2">
+						<span className="font-semibold text-2xl text-secondary">
+							Lerneinheit editieren
+						</span>
+						<h1 className="text-4xl">{initialLesson?.title || "<Titel>"}</h1>
+					</div>
+					<div className="pointer-events-auto flex items-center gap-2">
+						<GreyBoarderButton>
+							<span className={"text-gray-600"}>Abbrechen</span>
+						</GreyBoarderButton>
+						<button type="submit" className="btn-primary pointer-events-auto">
+							Speichern
+						</button>
 					</div>
 				</div>
-
-				<div
-					className={`${
-						isFullScreen ? "fixed" : ""
-					} pointer-events-none bottom-0 flex w-full items-end justify-end`}
-				>
-					<div className={`${isFullScreen ? "absolute" : "fixed"}  z-50 pr-5 pb-5`}>
-						<DialogActions onClose={onSubmit}>
-							<button type="submit" className="btn-primary pointer-events-auto">
-								Speichern
-							</button>
-						</DialogActions>
-					</div>
-				</div>
+				<Tabs selectedIndex={selectedTab} onChange={v => setSelectedTab(v)}>
+					<Tab>Lernangaben</Tab>
+					<Tab>Lerninhalt</Tab>
+					<Tab>Lernkontrolle</Tab>
+				</Tabs>
+				{selectedTab === 0 && <LessonInfoEditor />}
+				{selectedTab === 1 && <LessonContentEditor />}
+				{selectedTab === 2 && <QuizEditor />}
 			</form>
 		</FormProvider>
 	);

--- a/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
+++ b/libs/feature/teaching/src/lib/lesson/lesson-editor.tsx
@@ -47,6 +47,7 @@ export async function onLessonEditorSubmit(
 	}) => Promise<{ title: string }>,
 	lesson?: LessonFormModel
 ) {
+	console.log("JKHFHUIHUIYIUHHIUUHOOUHIJIOUH");
 	try {
 		if (lesson) {
 			const result = await editLessonAsync({
@@ -94,7 +95,9 @@ export function LessonEditor({
 		<FormProvider {...form}>
 			<form
 				id="lessonform"
-				onSubmit={form.handleSubmit(onSubmit, console.log)}
+				onSubmit={form.handleSubmit(onSubmit, error => {
+					console.log("EEE", error);
+				})}
 				className="flex flex-col"
 			>
 				<div className="flex overflow-x-hidden">
@@ -105,7 +108,7 @@ export function LessonEditor({
 							<LessonInfoEditor lesson={initialLesson} />
 						</div>
 
-						<div className="px-3">
+						<div className="pl-3">
 							<Tabs selectedIndex={selectedTab} onChange={v => setSelectedTab(v)}>
 								<Tab>Lerninhalt</Tab>
 								<Tab>Lernkontrolle</Tab>

--- a/libs/ui/common/src/lib/dropdown-menu/dropdown-menu.tsx
+++ b/libs/ui/common/src/lib/dropdown-menu/dropdown-menu.tsx
@@ -64,7 +64,7 @@ export function DropdownMenu({
 							style={{
 								minWidth: buttonRef.current?.offsetWidth || "auto"
 							}}
-							className={`absolute z-10 bg-white shadow-lg max-h-64 overflow-auto text-sm ${dropdownPosition === "top" ? "rounded-t" : "rounded-b"}`}
+							className={`absolute z-10 bg-white shadow-lg max-h-64 overflow-auto text-sm rounded`}
 						>
 							{childrenArray.map((element, i) => (
 								<MenuItem key={i}>

--- a/libs/ui/common/src/lib/tabs/tabs.tsx
+++ b/libs/ui/common/src/lib/tabs/tabs.tsx
@@ -59,7 +59,14 @@ export function RemovableTab({
 		<Tab>
 			<span className="flex items-end gap-4 hover:text-secondary">
 				<span>{children}</span>
-				<XButton onClick={onRemove} title="Entfernen" className="flex items-center" />
+				<XButton
+					onClick={e => {
+						e.stopPropagation();
+						onRemove();
+					}}
+					title="Entfernen"
+					className="flex items-center"
+				/>
 			</span>
 		</Tab>
 	);

--- a/libs/ui/layouts/src/index.ts
+++ b/libs/ui/layouts/src/index.ts
@@ -10,3 +10,4 @@ export * from "./lib/topic-header/topic-header";
 export * from "./lib/guards";
 export * from "./lib/search-bar";
 export * from "./lib/redirect-to-login";
+export * from "./lib/draggable/draggable";

--- a/libs/ui/layouts/src/lib/draggable/draggable.tsx
+++ b/libs/ui/layouts/src/lib/draggable/draggable.tsx
@@ -2,7 +2,7 @@
 
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
 import { Bars3Icon } from "@heroicons/react/24/outline";
-import { RemovableTab, Tab, Tabs, XButton } from "@self-learning/ui/common";
+import { RemovableTab, Tab, Tabs } from "@self-learning/ui/common";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type DraggableItem<T> = T & { id: string };
@@ -200,7 +200,13 @@ export function DraggableContentOutline<T extends { id: string }>({
 	removeContent?: (idx: number) => void;
 	activeIndex: number | undefined;
 	setTargetIndex: (idx: number) => void; // separate from activeIndex to avoid circle dependency
-	RenderContent: (props: { item?: T }) => JSX.Element;
+	RenderContent: (props: {
+		item?: T;
+		swappable?: boolean;
+		remove?: () => void;
+		select?: () => void;
+		active?: boolean;
+	}) => JSX.Element;
 }) {
 	return (
 		<DragDropContext
@@ -216,7 +222,7 @@ export function DraggableContentOutline<T extends { id: string }>({
 						{...provided.droppableProps}
 						className="overflow-y-auto"
 					>
-						<div className="flex flex-col flex-no-wrap gap-4 min-w-max">
+						<div className="flex flex-col flex-no-wrap min-w-max">
 							{content.map((item, index) => (
 								<Draggable
 									key={item.id}
@@ -229,21 +235,16 @@ export function DraggableContentOutline<T extends { id: string }>({
 											ref={provided.innerRef}
 											{...provided.draggableProps}
 											{...provided.dragHandleProps}
-											className={`flex gap-5 text-nowrap flex-nowrap items-center ${activeIndex === index ? "text-secondary" : "text-light"}`}
 										>
-											{swapContent && (
-												<Bars3Icon className="h-5 text-light" />
-											)}
-											<span onClick={() => setTargetIndex(index)}>
-												<RenderContent item={item} />
-											</span>
-											{removeContent && (
-												<XButton
-													onClick={() => removeContent(index)}
-													title="Entfernen"
-													className="flex items-center"
-												/>
-											)}
+											<RenderContent
+												item={item}
+												swappable={!!swapContent}
+												remove={
+													removeContent && (() => removeContent(index))
+												}
+												select={() => setTargetIndex(index)}
+												active={activeIndex === index}
+											/>
 										</div>
 									)}
 								</Draggable>

--- a/libs/ui/layouts/src/lib/draggable/draggable.tsx
+++ b/libs/ui/layouts/src/lib/draggable/draggable.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
+import { Bars3Icon } from "@heroicons/react/24/outline";
+import { RemovableTab, Tab, Tabs, XButton } from "@self-learning/ui/common";
+import { useEffect, useRef } from "react";
+
+/**
+ * @usage
+ * - Select combination of two elements: Viewer and Outline/Selector. You can use Outline/Selector separately from viewer
+ * - T must have a string id field.
+ * - Create your container of T[].
+ * - Create TWO useState<number | undefined>(undefined):
+ *   - activeIndex - holds current viewed element
+ *   - targetIndex - used to trigger scroll on click on the desired content
+ * - RenderContent for Viewer is a view for each T. Must have item: T and index: number fields.
+ *   - if supplied item is undefined => content array is empty
+ * - RenderContent for Outline/Selector is a view for each T. Must have item: T.
+ *   - Keep it simple! Ideally make it just text
+ *   - if supplied item is undefined => content array is empty
+ * !!! look carefully which indexes are supplied into components! Can cause nasty errors!
+ *
+ * resetTargetIndex - set it to `() => setTargetIndex(nullptr)`
+ */
+export function DraggableContentViewer<T extends { id: string }>({
+	content,
+	setActiveIndex,
+	targetIndex, // separate from activeIndex to avoid circle dependency
+	resetTargetIndex,
+	RenderContent
+}: {
+	content: T[];
+	setActiveIndex: (idx: number | undefined) => void;
+	targetIndex: number | undefined;
+	resetTargetIndex: () => void;
+	RenderContent: (props: { item?: T; index?: number }) => JSX.Element;
+}) {
+	const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
+	const visibleItemsRef = useRef<Set<number>>(new Set());
+	// scroll into selected
+	useEffect(() => {
+		if (targetIndex !== undefined && content[targetIndex] && contentRefs.current[targetIndex]) {
+			contentRefs.current[targetIndex].scrollIntoView({
+				behavior: "smooth",
+				block: "start"
+			});
+			resetTargetIndex();
+		}
+	}, [targetIndex]); // Deliberately avoid update on content to avoid scroll on delete, on swap, .... Allow only on click
+	// Detect active element
+	const calculateMinVisibleIndex = () => {
+		if (visibleItemsRef.current.size === 0) return undefined;
+		let min: number | undefined;
+		for (const idx of visibleItemsRef.current) {
+			if (min === undefined || idx < min) min = idx;
+		}
+		return min;
+	};
+	useEffect(() => {
+		const remInPx = parseInt(getComputedStyle(document.documentElement).fontSize);
+		console.log(`${4 * remInPx}px 0px 0px 0px`);
+
+		const observer = new IntersectionObserver(
+			entries => {
+				entries.forEach(entry => {
+					const indexStr = (entry.target as HTMLElement).dataset?.["activeIndex"];
+					if (indexStr !== undefined) {
+						const index = parseInt(indexStr, 10);
+						if (entry.isIntersecting) {
+							visibleItemsRef.current.add(index);
+						} else {
+							visibleItemsRef.current.delete(index);
+						}
+					}
+				});
+				const newActiveIndex = calculateMinVisibleIndex();
+				setActiveIndex(newActiveIndex); // React ignores same index update
+			},
+			{
+				root: null,
+				rootMargin: `-${4 * remInPx}px 0px 0px 0px`,
+				threshold: 0.01
+			}
+		);
+
+		contentRefs.current.forEach(ref => {
+			if (ref) {
+				observer.observe(ref);
+			}
+		});
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [content, setActiveIndex]);
+
+	if (!content || content.length === 0) {
+		return (
+			<div>
+				<RenderContent />
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-4">
+			{content.map((item, index) => (
+				<div
+					key={item.id}
+					ref={el => {
+						contentRefs.current[index] = el;
+					}}
+					// Add a data attribute to easily retrieve the index in the Intersection Observer callback
+					data-active-index={index}
+					// Scroll positioning fix because of website header
+					className="scroll-mt-16"
+				>
+					<RenderContent index={index} item={item} />
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function DraggableContentOutline<T extends { id: string }>({
+	content,
+	swapContent,
+	removeContent,
+	activeIndex,
+	setTargetIndex,
+	RenderContent
+}: {
+	content: T[];
+	swapContent: (src: number, dest: number) => void;
+	removeContent?: (idx: number) => void;
+	activeIndex: number | undefined;
+	setTargetIndex: (idx: number) => void; // separate from activeIndex to avoid circle dependency
+	RenderContent: (props: { item?: T }) => JSX.Element;
+}) {
+	return (
+		<DragDropContext
+			onDragEnd={result => {
+				if (result.reason !== "DROP" || !result.destination) return;
+				swapContent(result.source.index, result.destination.index);
+			}}
+		>
+			<Droppable droppableId="droppable" direction="vertical">
+				{provided => (
+					<div
+						ref={provided.innerRef}
+						{...provided.droppableProps}
+						className="overflow-y-auto"
+					>
+						<div className="flex flex-col flex-no-wrap gap-4 min-w-max">
+							{content.map((item, index) => (
+								<Draggable key={item.id} draggableId={item.id} index={index}>
+									{provided => (
+										<div
+											ref={provided.innerRef}
+											{...provided.draggableProps}
+											{...provided.dragHandleProps}
+											className={`flex gap-5 text-nowrap flex-nowrap items-center ${activeIndex === index ? "text-secondary" : "text-light"}`}
+										>
+											<Bars3Icon className="h-5 text-light" />
+											<span onClick={() => setTargetIndex(index)}>
+												<RenderContent item={item} />
+											</span>
+											{removeContent && (
+												<XButton
+													onClick={() => removeContent(index)}
+													title="Entfernen"
+													className="flex items-center"
+												/>
+											)}
+										</div>
+									)}
+								</Draggable>
+							))}
+							{(!content || content.length === 0) && (
+								<div className={`flex gap-5 text-nowrap flex-nowrap items-center`}>
+									<span>
+										<RenderContent />
+									</span>
+								</div>
+							)}
+						</div>
+						{provided.placeholder}
+					</div>
+				)}
+			</Droppable>
+		</DragDropContext>
+	);
+}
+
+export function DraggableContentSelector<T extends { id: string }>({
+	content,
+	swapContent,
+	removeContent,
+	activeIndex,
+	selectContentIndex,
+	RenderContent
+}: {
+	content: T[];
+	swapContent: (src: number, dest: number) => void;
+	removeContent?: (idx: number) => void;
+	activeIndex: number | undefined;
+	selectContentIndex: (idx: number) => void;
+	RenderContent: (props: { item?: T }) => JSX.Element;
+}) {
+	return (
+		<DragDropContext
+			onDragEnd={result => {
+				if (result.reason !== "DROP" || !result.destination) return;
+				swapContent(result.source.index, result.destination.index);
+			}}
+		>
+			<Droppable droppableId="droppable" direction="horizontal">
+				{provided => (
+					<div
+						ref={provided.innerRef}
+						{...provided.droppableProps}
+						className="overflow-auto"
+					>
+						<Tabs selectedIndex={activeIndex} onChange={selectContentIndex}>
+							<div className="flex flex-no-wrap gap-4 min-w-max">
+								{content.map((item, index) => (
+									<Draggable key={item.id} draggableId={item.id} index={index}>
+										{provided => (
+											<div
+												ref={provided.innerRef}
+												{...provided.draggableProps}
+												{...provided.dragHandleProps}
+											>
+												{removeContent && (
+													<RemovableTab
+														onRemove={() => removeContent(index)}
+													>
+														<div className="flex gap-5 items-center">
+															<Bars3Icon className="h-5 text-light" />
+															<RenderContent item={item} />
+														</div>
+													</RemovableTab>
+												)}
+												{!removeContent && (
+													<Tab>
+														<div className="flex gap-5 items-center">
+															<Bars3Icon className="h-5 text-light" />
+															<RenderContent item={item} />
+														</div>
+													</Tab>
+												)}
+											</div>
+										)}
+									</Draggable>
+								))}
+								{(!content || content.length === 0) && (
+									<Draggable key={"null"} draggableId={"null"} index={0}>
+										{provided => (
+											<div
+												ref={provided.innerRef}
+												{...provided.draggableProps}
+												{...provided.dragHandleProps}
+												className={`flex gap-5 text-nowrap flex-nowrap items-center`}
+											>
+												<Bars3Icon className="h-5 text-light" />
+												<span>
+													<RenderContent />
+												</span>
+											</div>
+										)}
+									</Draggable>
+								)}
+							</div>
+						</Tabs>
+						{provided.placeholder}
+					</div>
+				)}
+			</Droppable>
+		</DragDropContext>
+	);
+}

--- a/libs/ui/lesson/src/lib/playlist/playlist.tsx
+++ b/libs/ui/lesson/src/lib/playlist/playlist.tsx
@@ -7,6 +7,7 @@ import {
 	PlayIcon
 } from "@heroicons/react/24/solid";
 import { trpc } from "@self-learning/api-client";
+import { useLessonLayout } from "@self-learning/lesson";
 import { CourseCompletion, extractLessonIds, LessonMeta } from "@self-learning/types";
 import { Divider, ProgressBar, useTimeout } from "@self-learning/ui/common";
 import Link from "next/link";
@@ -158,26 +159,30 @@ function Lesson({
 	href: string;
 	isActive: boolean;
 }) {
+	const { playlistRef } = useLessonLayout();
 	return (
-		<Link
-			href={href}
-			className={`relative flex items-center overflow-hidden rounded-lg py-1 px-4 hover:bg-gray-200 ${
-				isActive ? "bg-gray-200 font-medium text-black" : "text-light"
-			}`}
-		>
-			<span
-				style={{ width: lesson.isCompleted ? "2px" : "1px" }}
-				className={`absolute h-full ${
-					lesson.isCompleted ? "bg-emerald-500" : "bg-gray-300"
+		<>
+			<Link
+				href={href}
+				className={`relative flex items-center overflow-hidden rounded-lg py-1 px-4 hover:bg-gray-200 ${
+					isActive ? "bg-gray-200 font-medium text-black" : "text-light"
 				}`}
-			></span>
-			<span
-				className="overflow-hidden text-ellipsis whitespace-nowrap pl-4 text-sm"
-				data-testid="lessonTitle"
 			>
-				{lesson.title}
-			</span>
-		</Link>
+				<span
+					style={{ width: lesson.isCompleted ? "2px" : "1px" }}
+					className={`absolute h-full ${
+						lesson.isCompleted ? "bg-emerald-500" : "bg-gray-300"
+					}`}
+				></span>
+				<span
+					className="overflow-hidden text-ellipsis whitespace-nowrap pl-4 text-sm"
+					data-testid="lessonTitle"
+				>
+					{lesson.title}
+				</span>
+			</Link>
+			{isActive && <div className="ml-8 mt-1" ref={playlistRef}></div>}
+		</>
 	);
 }
 

--- a/libs/ui/lesson/src/lib/playlist/playlist.tsx
+++ b/libs/ui/lesson/src/lib/playlist/playlist.tsx
@@ -213,8 +213,6 @@ function PlaylistHeader({ content, course, lesson, completion }: PlaylistProps) 
 }
 
 function CurrentlyPlaying({ lesson, content, course }: PlaylistProps) {
-	const router = useRouter();
-
 	const currentChapter = useMemo(() => {
 		for (const chapter of content) {
 			for (const les of chapter.content) {
@@ -227,20 +225,6 @@ function CurrentlyPlaying({ lesson, content, course }: PlaylistProps) {
 		return null;
 	}, [content, lesson]);
 
-	const { previous, next } = useMemo(() => {
-		const flatLessons = content.flatMap(chapter => chapter.content);
-		const lessonIndex = flatLessons.findIndex(l => l.lessonId === lesson.lessonId);
-
-		return {
-			previous: lessonIndex > 0 ? flatLessons[lessonIndex - 1] : null,
-			next: lessonIndex < flatLessons.length - 1 ? flatLessons[lessonIndex + 1] : null
-		};
-	}, [content, lesson]);
-
-	function navigateToLesson(lesson: PlaylistLesson) {
-		router.push(`/courses/${course.slug}/${lesson.slug}`);
-	}
-
 	return (
 		<div className="flex flex-col gap-4" data-testid="CurrentlyPlaying">
 			<span className="flex items-center gap-2 text-sm">
@@ -251,40 +235,6 @@ function CurrentlyPlaying({ lesson, content, course }: PlaylistProps) {
 				<span className="text-light">-</span>
 				<span className="overflow-hidden text-ellipsis whitespace-nowrap font-medium text-secondary">
 					{lesson.title}
-				</span>
-			</span>
-			<span className="flex justify-between">
-				{lesson.meta.hasQuiz && (
-					<Link
-						href={`/courses/${course.slug}/${lesson.slug}${
-							router.pathname.endsWith("quiz") ? "" : "/quiz"
-						}`}
-						className="btn-primary text-sm"
-						data-testid="quizLink"
-					>
-						{router.pathname.endsWith("quiz") ? "Zum Lernhinhalt" : "Zur Lernkontrolle"}
-					</Link>
-				)}
-
-				<span className="flex gap-2">
-					<button
-						onClick={() => previous && navigateToLesson(previous)}
-						disabled={!previous}
-						className="rounded-lg border border-light-border p-2 disabled:text-gray-300"
-						title="Vorherige Lerneinheit"
-						data-testid="previousLessonButton"
-					>
-						<ChevronDoubleLeftIcon className="h-5" />
-					</button>
-					<button
-						onClick={() => next && navigateToLesson(next)}
-						disabled={!next}
-						className="rounded-lg border border-light-border p-2 disabled:text-gray-300"
-						title="Nächste Lerneinheit"
-						data-testid="nextLessonButton"
-					>
-						<ChevronDoubleRightIcon className="h-5" />
-					</button>
 				</span>
 			</span>
 		</div>

--- a/libs/util/common/src/lib/date.ts
+++ b/libs/util/common/src/lib/date.ts
@@ -11,6 +11,7 @@ import { formatInTimeZone } from "date-fns-tz";
  * formatSeconds(3600); // "01:00:00"
  */
 export function formatSeconds(seconds: number): string {
+	if (Number.isNaN(seconds) || seconds < 0) return "";
 	const hours = Math.floor(seconds / 3600);
 	const minutes = Math.floor((seconds % 3600) / 60);
 	const secondsLeft = seconds % 60;

--- a/libs/util/types/src/lib/lesson-content.ts
+++ b/libs/util/types/src/lib/lesson-content.ts
@@ -80,7 +80,7 @@ export type ValueByContentType<CType extends LessonContentType["type"]> =
 
 export type MetaByContentType<CType extends LessonContentType["type"]> =
 	InferContentType<CType>["meta"];
-
+// TODO unused
 export function findContentType<CType extends LessonContentType["type"]>(
 	type: CType,
 	content: LessonContent

--- a/libs/util/types/src/lib/lesson-content.ts
+++ b/libs/util/types/src/lib/lesson-content.ts
@@ -51,6 +51,8 @@ export const lessonContentSchema = z.discriminatedUnion("type", [
 	iframeSchema
 ]);
 
+export const CONTENT_TYPES = ["video", "article", "pdf", "iframe"] as const;
+
 export function getContentTypeDisplayName(contentType: LessonContentMediaType): string {
 	const names: { [contentType in LessonContentMediaType]: string } = {
 		video: "Video",

--- a/libs/util/types/src/lib/lesson-content.ts
+++ b/libs/util/types/src/lib/lesson-content.ts
@@ -6,8 +6,7 @@ export const videoSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		duration: z.number(),
-		id: z.string()
+		duration: z.number()
 	})
 });
 
@@ -17,8 +16,7 @@ export const articleSchema = z.object({
 		content: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number(),
-		id: z.string()
+		estimatedDuration: z.number()
 	})
 });
 
@@ -28,8 +26,7 @@ export const pdfSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number(),
-		id: z.string()
+		estimatedDuration: z.number()
 	})
 });
 
@@ -39,8 +36,7 @@ export const iframeSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number(),
-		id: z.string()
+		estimatedDuration: z.number()
 	})
 });
 

--- a/libs/util/types/src/lib/lesson-content.ts
+++ b/libs/util/types/src/lib/lesson-content.ts
@@ -6,7 +6,8 @@ export const videoSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		duration: z.number()
+		duration: z.number(),
+		id: z.string()
 	})
 });
 
@@ -16,7 +17,8 @@ export const articleSchema = z.object({
 		content: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number()
+		estimatedDuration: z.number(),
+		id: z.string()
 	})
 });
 
@@ -26,7 +28,8 @@ export const pdfSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number()
+		estimatedDuration: z.number(),
+		id: z.string()
 	})
 });
 
@@ -36,7 +39,8 @@ export const iframeSchema = z.object({
 		url: z.string()
 	}),
 	meta: z.object({
-		estimatedDuration: z.number()
+		estimatedDuration: z.number(),
+		id: z.string()
 	})
 });
 


### PR DESCRIPTION
# Learning Content Refactoring

## Detailed Changes:

- **add** reusable Draggable Components in ui lib layouts:
  - **DraggableContentOutline** - component which creates a vertical draggable area with tabs.
    - Each tab can be cutomized through RenderContent. 
    - Tabs can be removable and/or draggable.
    - setTargetIndex allows to listen for user selection.
    - activeIndex defines which index is highligted now.
  - **DraggableContentViewer** - component which creates vertical area with each element stacked on top of each other with ability to scroll to each indiuvidual element.
    - RenderContent with custom renderProps.
    - targetIndex controls to which item the scroll will be performed.
    - setActiveIndex allows to get info which element now viewed by user.
  - **useDraggableContent** - helper which holds all required methods to use **Outline** and **Viewer** together. Nevertheless, it is easy to use them with custom data.
    - automatically creates and tracks field with uid if not already provided.
    - provides CRUD operations.
  - **Outline** and **Viewer** can be used separately from each other.
  - Important! activeIndex and targetIndex must not be mixed - that will lead to circular dependency.
- *add* playlist outline of the current lesson's contents.
- *add* lesson editor outline of the lesson contents
- Further changes are associated with issue #371 

## List of addressed problems

### Issue #366 

The data model for learning units is to be expanded to allow multiple learning contents of the same type in any order. In addition, a visual field for "references"/"sources" are to be added and the previous “preferred content type” removed.

- [x] **Allow multiple content of the same type**

A learning unit can contain text, video, PDF, and external URL combinations. Several items of the same type are allowed (e.g., two texts and three PDFs).

- [x] **Sequence of the learning content**

The content within a learning unit should be saved and displayed in any order defined by the author.

- [ ] **Additional field: Sources / literature** _(will be addressed in separate PR)_

The learning unit contains an optional field references (string or rich text), which can contain sources or further reading.

- [x] **Removal of the preferred content type**

### Issue #368 

- [x] - Merge the buttons for creating content into a drop-down button.
- [x] - Allow rearranging the order of learning content by moving the tabs.
- [ ] - Add an optional area for sources/additional literature. _(will be addressed in separate PR)_

<img width="343" height="243" alt="image" src="https://github.com/user-attachments/assets/b3054928-3ead-419a-bd61-f4b4eae18562" />
<img width="459" height="582" alt="image" src="https://github.com/user-attachments/assets/80aa4e4c-11fb-4caf-9dce-e6db1321a427" />


### Issue #369 

**Navigation within learning unit**

- [x] - Remove the “Zum Lerninhalt” (jump to content) and “Zur Lernkontrolle” (jump to quiz) buttons from the sidebar playlist area.
- [x] - Place the buttons for changing between content and quiz in the new tab component

Content PDF PDF Sources [Zur Lernkontrolle]

**Local Navigation between adjacent learning units**

- [x] - Remove the “<<” and “>>” buttons for changing adjacent learning units from the sidebar playlist area.
- [x] - Place buttons for changing learning units below the learning content.

- [x] - [<< Previous unit] aligned to the left
- [x] - [Next unit >>] aligned to the right

<img width="2623" height="1156" alt="image" src="https://github.com/user-attachments/assets/f360211b-8413-4b01-8b37-551fa89100ab" />
<img width="2610" height="1154" alt="image" src="https://github.com/user-attachments/assets/e8b0eadf-b1c9-4b95-91cf-3beee37a10b5" />

### Issue #400

### Outline (right sidebar)

- [x] - Display created content elements and their order
- [x] - Rearrange content elements with drag and drop
- [x] - Select content elements to jump to them (read more below)
- [x] - Scrollable, if there are many elements

- [ ] The right sidebar element will be used for different purposes at a later point. One use case will be displaying the outline of quiz questions. _(requires more clarification and additional PR)_

<img width="430" height="574" alt="image" src="https://github.com/user-attachments/assets/827a8775-e88d-4a4b-91ce-61841d3a4c48" />


### Editor (middle)

**Add Content Button**

- [x] - Dropdown Button with Buttons for Text, Video, PDF, and External Page.
- [x] - Newly added elements will appear as the last element in the outline

<img width="321" height="215" alt="image" src="https://github.com/user-attachments/assets/c2233214-4385-4518-b9ff-c3d832dc5511" />


**Content**

- [x] - All content editing fields are displayed below each other ('infinite' scroll)
- [x] - Content editing fields are in the same order as in the outline
- [x] - Editing fields have 'anchors'. Clicking a content element in the outline will directly scroll to the selected element inside the editor.
- [x] - Reaching an 'anchor' while scrolling in the editor will update the selected outline element.

<img width="954" height="1219" alt="image" src="https://github.com/user-attachments/assets/7a408e92-a85f-4fd7-a726-e7b9243bcd3c" />


### Issue #367

- [x] - Display header for learning units with course title, learning unit title, subtitle, authors and license above the learning content.
- [x] - Optional description of the learning unit is located below the header.
  - [ ]   - For very long descriptions this field should be expandable (only show first x words and have a "show more" and "show less" button that collapses the view; no dialog)  _(will be addressed in separate PR)_
- [x] - Actual learning content (with tabs) starts below the description.

Tabbed Structure

- [x] - The student view has a primary tab for the learning content.
  - [x]   - Learning content in the primary tab is displayed one below the other and can be scrolled.
  - [x]   - Video player is embedded in the content (text width).
  - [x]   - An anchor (placeholder component) is embedded in the content for each PDF. This anchor contains a button that leads to the PDF.
- [x] - An additional tab is created for each uploaded PDF in the learning unit. 
  - [x]   - Clicking on an additional tab changes the focus. 
  - [x]   - The uploaded PDF is displayed in the browser's PDF viewer in the content field of the tab.
  - [x]   - Clicking on an anchor in the learning content changes the focus to the tab containing the PDF.

Other

- [ ] - “Zur Lerneinheit” button in a quiz points to the primary tab for the learning content.  _(will be addressed in separate PR)_

<img width="2828" height="1152" alt="image" src="https://github.com/user-attachments/assets/6216fdf8-2f3f-47e1-b107-88e4057709f6" />

<img width="2853" height="1199" alt="image" src="https://github.com/user-attachments/assets/a74cb21c-9536-409c-99f3-730c5f1f6ade" />
