### PR TITLE
feat(api): add course progress endpoint for teachers

### DIFF
--- a/libs/data-access/api/src/lib/trpc/routers/course.router.rest.spec.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/course.router.rest.spec.ts
@@ -8,7 +8,14 @@ jest.mock("@self-learning/database", () => ({
 	database: {
 		course: {
 			findUnique: jest.fn(),
+			findMany: jest.fn(),
+			findFirst: jest.fn()
+		},
+		enrollment: {
 			findMany: jest.fn()
+		},
+		completedLesson: {
+			groupBy: jest.fn()
 		}
 	}
 }));
@@ -207,6 +214,218 @@ describe("REST API of Course Router", () => {
 			});
 
 			expect(response.statusCode).toBe(401);
+		});
+	});
+
+	// testing of getProgress end-point
+	describe("[GET]: /courses/{slug}/progress", () => {
+		const courseMock = createCourseMock({
+			courseId: "course1",
+			slug: "test-course",
+			title: "Test Course",
+			authors: ["teacher1", "teacher2"], // Multiple authors
+			content: [
+				{
+					chapterTitle: "Chapter 1",
+					lessons: ["lesson1", "lesson2", "lesson3", "lesson4"]
+				}
+			]
+		});
+
+		// Test users
+		const courseAuthor1: UserFromSession = {
+			id: "1",
+			name: "teacher1", // First author - should have access
+			role: "USER",
+			isAuthor: true,
+			avatarUrl: null,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false
+		};
+
+		const courseAuthor2: UserFromSession = {
+			id: "2",
+			name: "teacher2", // Second author - should also have access
+			role: "USER",
+			isAuthor: true,
+			avatarUrl: null,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false
+		};
+
+		const nonAuthor: UserFromSession = {
+			id: "3",
+			name: "teacher3", // Not an author of this course - should be blocked
+			role: "USER",
+			isAuthor: true,
+			avatarUrl: null,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false
+		};
+
+		const adminNonAuthor: UserFromSession = {
+			id: "4",
+			name: "admin1", // Admin but NOT author of this course - should be blocked
+			role: "ADMIN",
+			isAuthor: true,
+			avatarUrl: null,
+			enabledFeatureLearningDiary: false,
+			enabledLearningStatistics: false
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+
+			// Mock course.findFirst for authorization check
+			(database.course.findFirst as jest.Mock).mockImplementation(async query => {
+				// Check if the requesting user is one of the course authors
+				const requestingUser = query.where.authors?.some?.username;
+				const courseAuthors = ["teacher1", "teacher2"]; // Multiple authors
+
+				if (courseAuthors.includes(requestingUser)) {
+					return {
+						courseId: courseMock.courseId,
+						content: courseMock.content
+					};
+				}
+				return null; // User is not an author (includes admins who aren't authors)
+			});
+
+			// Mock enrollment.findMany for enrolled students check
+			(database.enrollment.findMany as jest.Mock).mockImplementation(async query => {
+				const requestedUsernames = query.where.username.in || [];
+				const allEnrollments = [
+					{ username: "student1" },
+					{ username: "student2" }
+					// Note: student3 is NOT enrolled
+				];
+
+				return allEnrollments.filter(enrollment =>
+					requestedUsernames.includes(enrollment.username)
+				);
+			});
+
+			// Mock completedLesson.groupBy for progress data
+			(database.completedLesson.groupBy as jest.Mock).mockImplementation(async query => {
+				const requestedUsernames = query.where.username?.in || [];
+
+				// Simulate different progress levels
+				const progressData = [
+					{ username: "student1", _count: { lessonId: 2 } }, // 2/4 = 50%
+					{ username: "student2", _count: { lessonId: 4 } } // 4/4 = 100%
+				];
+
+				return progressData.filter(data => requestedUsernames.includes(data.username));
+			});
+		});
+
+		it("should return progress for enrolled students only", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1,student2,student3" // student3 not enrolled
+				},
+				user: courseAuthor1 // First author
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual([
+				{ username: "student1", progress: 50 }, // 2/4 lessons = 50%
+				{ username: "student2", progress: 100 } // 4/4 lessons = 100%
+				// student3 not in results (not enrolled)
+			]);
+		});
+
+		it("should allow access for second course author", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1,student2"
+				},
+				user: courseAuthor2 // Second author should also have access
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual([
+				{ username: "student1", progress: 50 },
+				{ username: "student2", progress: 100 }
+			]);
+		});
+
+		it("should return empty array when no usernames provided", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"]
+					// No usernames parameter
+				},
+				user: courseAuthor1
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual([]);
+		});
+
+		it("should return 403 for non-author users", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1,student2"
+				},
+				user: nonAuthor // This user is NOT an author of the course
+			});
+
+			expect(response.statusCode).toBe(403);
+		});
+
+		it("should return 403 for admin users who are not course authors", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1,student2"
+				},
+				user: adminNonAuthor // Admin but NOT author of this course
+			});
+
+			expect(response.statusCode).toBe(403);
+		});
+
+		it("should return 401 for unauthorized requests", async () => {
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1,student2"
+				}
+				// No user provided at all
+			});
+
+			expect(response.statusCode).toBe(401);
+		});
+
+		it("should handle students with zero progress", async () => {
+			// Override the completedLesson mock for this test
+			(database.completedLesson.groupBy as jest.Mock).mockImplementationOnce(async () => {
+				return []; // No completed lessons
+			});
+
+			const response = await restQuery({
+				method: "GET",
+				query: {
+					trpc: ["courses", "test-course", "progress"],
+					usernames: "student1"
+				},
+				user: courseAuthor1
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual([
+				{ username: "student1", progress: 0 } // 0/4 lessons = 0%
+			]);
 		});
 	});
 });

--- a/libs/data-access/api/src/lib/trpc/routers/course.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/course.router.ts
@@ -329,6 +329,117 @@ export const courseRouter = t.router({
 					}
 				}
 			});
+		}),
+
+	getProgress: authorProcedure
+		.meta({
+			openapi: {
+				enabled: true,
+				method: "GET",
+				path: "/courses/{slug}/progress",
+				tags: ["Courses"],
+				protect: true,
+				summary: "Get course progress for a list of students (teachers/admins only)"
+			}
+		})
+		.input(
+			z.object({
+				slug: z.string().describe("Unique slug of the course"),
+				usernames: z
+					.string()
+					.optional()
+					.describe(
+						"Comma separated list of student usernames to get progress for, e.g. 'user1,user2'"
+					)
+			})
+		)
+		.output(
+			z.array(
+				z.object({
+					username: z.string(),
+					progress: z.number().min(0).max(100).nullable()
+				})
+			)
+		)
+		.query(async ({ input, ctx }) => {
+			const usernames = input.usernames
+				? input.usernames
+						.split(",")
+						.map(u => u.trim())
+						.filter(Boolean)
+				: [];
+
+			// Verify user is author of the course
+			const course = await database.course.findFirst({
+				where: {
+					slug: input.slug,
+					authors: { some: { username: ctx.user.name } }
+				},
+				select: {
+					courseId: true,
+					content: true
+				}
+			});
+		
+			if (!course) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You are not an author of this course."
+				});
+			}
+
+			const content = (course.content ?? []) as CourseContent;
+			const lessonIds = extractLessonIds(content);
+			const totalLessons = lessonIds.length;
+
+			if (totalLessons === 0) {
+				return usernames.map(username => ({
+					username,
+					progress: null
+				}));
+			}
+
+			// Find enrolled students from input usernames in this course
+			const enrollments = await database.enrollment.findMany({
+				where: {
+					courseId: course.courseId,
+					username: { in: usernames }
+				},
+				select: {
+					username: true
+				}
+			});
+
+			if (enrollments.length === 0) {
+				return [];
+			}
+
+			// Count completed lessons per student
+			const completedLessons = await database.completedLesson.groupBy({
+				by: ["username"],
+				where: {
+					courseId: course.courseId,
+					lessonId: { in: lessonIds },
+					username: { in: enrollments.map(e => e.username) }
+				},
+				_count: {
+					lessonId: true
+				}
+			});
+
+			const completedMap = new Map<string, number>();
+			for (const c of completedLessons) {
+				completedMap.set(c.username, c._count.lessonId);
+			}
+
+			return enrollments.map(enrollment => {
+				const completedCount = completedMap.get(enrollment.username) ?? 0;
+				const progressPercent = Math.round((completedCount / totalLessons) * 100);
+				return {
+					username: enrollment.username,
+					progress: progressPercent
+				};
+			});
 		})
 });
 


### PR DESCRIPTION
Implements `GET /courses/{slug}/progress` endpoint allowing course authors to query student progress.

**Features:**
- Returns completion percentage for specified students
- Only shows data for enrolled students  
- Restricted to course authors only
- Handles edge cases (empty courses, non-enrolled students)

**Security:** 
- Uses `authorProcedure` for authorization
- Database-level filtering by course authorship

**Current State:** In review