### PR TITLE
fix(question-types): Avoid clozes to crash when punctuation is used

### DIFF
--- a/libs/feature/question-types/src/lib/question-types/cloze/cloze-parser.spec.ts
+++ b/libs/feature/question-types/src/lib/question-types/cloze/cloze-parser.spec.ts
@@ -59,6 +59,14 @@ describe("Cloze Parser", () => {
 			const gaps = parseCloze(text);
 			expect(gaps).toHaveLength(1);
 		});
+
+		it("should accept punctuation, whitespaces, and unicode", () => {
+			const text =
+				"{C: [#a, b, e.f, g-h, i!j, k?l, m@n, o#p, q$r, s%t, u^v, w&x, y*z, ÄäÜüÖöß, 😎, Text with whitespace]}";
+			const gaps = parseCloze(text);
+			expect(gaps).toHaveLength(1);
+			expect(gaps[0].values).toHaveLength(16);
+		});
 	});
 
 	describe("insertPlaceholder", () => {

--- a/libs/feature/question-types/src/lib/question-types/cloze/cloze-parser.ts
+++ b/libs/feature/question-types/src/lib/question-types/cloze/cloze-parser.ts
@@ -12,9 +12,10 @@ export type Gap = {
 // {T: [Text]}
 // {T: [Text, Alternative]}
 
-//Cloze regex catches all cloze gaps in the text
+// Cloze regex catches all cloze gaps in the text
+// [^,\[\]\s]+ matches any character except: , [ or ]
 // eslint-disable-next-line no-useless-escape
-const clozeRegex = /(?:{[TC]\: \[((?:#*(?:[\w-ÄäÜüÖö]+|(?:\$\$.+\$\$)),* *)+)\]})/gm;
+const clozeRegex = /(?:{[TC]\: \[((?:#*(?:[^,\[\]]+|(?:\$\$.+\$\$)),* *)+)\]})/gm;
 
 //Latex regex detects if latex is used in the cloze gap
 // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
# Previous bug
Entering `{C: Correct, #In-correct}` in a cloze exercise caused a crash and the entire editor was closed.

# Fix
The fix supports any answer as long it does not contain `,`, `[` or `]`. This supports any punctuation as well as Unicode characters.