### PR TITLE
fix(ui-forms): Prevents "Edit as JSON" button to automatically save & close

### DIFF
--- a/libs/ui/forms/src/lib/json-editor-dialog.tsx
+++ b/libs/ui/forms/src/lib/json-editor-dialog.tsx
@@ -48,7 +48,7 @@ export function JsonEditorDialog<T>({
 	}
 
 	return (
-		<Dialog open={true} onClose={handleOutsideClick()} className="relative z-50">
+		<Dialog open={true} onClose={handleOutsideClick} className="relative z-50">
 			{/* The backdrop, rendered as a fixed sibling to the panel container */}
 			<div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
@@ -140,7 +140,7 @@ export function OpenAsJsonButton({
 	const { t } = useTranslation("common");
 
 	return (
-		<button className="btn btn-tertiary" onClick={openJsonEditor}>
+		<button className="btn btn-tertiary" onClick={openJsonEditor} type="button">
 			<span className={"text-gray-600"}>{t("Edit as JSON")}</span>
 			{isJsonEditorOpen && (
 				<JsonEditorDialog onClose={onCloseJsonEditor} validationSchema={validationSchema} />


### PR DESCRIPTION
- Changes type of `OpenAsJsonButton` from (implicit) `submit` to `button` to avoid automatic form update when used inside a form (which is usually the case).
- UI enhacement: Restricts upload progress dialog to show only 2 digits while uploading (smal improvement, which is technically not related to this issue).

closes #445