### PR TITLE
fix(course-delete): lazy-load findLinkedEntities on delete click

### DIFF
--- a/apps/site/pages/dashboard/author/index.tsx
+++ b/apps/site/pages/dashboard/author/index.tsx
@@ -407,7 +407,10 @@ function AuthorDashboardPage({ author }: Props) {
 
 function CourseDeleteOption({ slug }: { slug: string }) {
 	const { mutateAsync: deleteCourse } = trpc.course.deleteCourse.useMutation();
-	const { data: linkedEntities, isLoading } = trpc.course.findLinkedEntities.useQuery({ slug });
+	const {
+		data: linkedEntities,
+		refetch
+	} = trpc.course.findLinkedEntities.useQuery({ slug }, { enabled: false }); // Prevent DB call on page load
 	const [showConfirmation, setShowConfirmation] = useState(false);
 	const { reload } = useRouter();
 
@@ -426,17 +429,15 @@ function CourseDeleteOption({ slug }: { slug: string }) {
 		setShowConfirmation(false);
 	};
 
-	// Don't show delete button -> Empty option
-	if (isLoading) {
-		return <></>;
-	}
-
 	return (
 		<>
 			<IconOnlyButton
 				icon={<TrashIcon className="h-5 w-5" />}
 				className="btn-danger"
-				onClick={() => setShowConfirmation(true)}
+				onClick={() => {
+					refetch(); // Lazy-load linked entities only when delete is initiated
+					setShowConfirmation(true);
+				}}
 			/>
 			{showConfirmation && (
 				<CourseDeletionDialog

--- a/apps/site/pages/dashboard/author/index.tsx
+++ b/apps/site/pages/dashboard/author/index.tsx
@@ -407,10 +407,10 @@ function AuthorDashboardPage({ author }: Props) {
 
 function CourseDeleteOption({ slug }: { slug: string }) {
 	const { mutateAsync: deleteCourse } = trpc.course.deleteCourse.useMutation();
-	const {
-		data: linkedEntities,
-		refetch
-	} = trpc.course.findLinkedEntities.useQuery({ slug }, { enabled: false }); // Prevent DB call on page load
+	const { data: linkedEntities, refetch } = trpc.course.findLinkedEntities.useQuery(
+		{ slug },
+		{ enabled: false }
+	); // Prevent DB call on page load
 	const [showConfirmation, setShowConfirmation] = useState(false);
 	const { reload } = useRouter();
 
@@ -434,8 +434,8 @@ function CourseDeleteOption({ slug }: { slug: string }) {
 			<IconOnlyButton
 				icon={<TrashIcon className="h-5 w-5" />}
 				className="btn-danger"
-				onClick={() => {
-					refetch(); // Lazy-load linked entities only when delete is initiated
+				onClick={async () => {
+					await refetch(); // Lazy-load linked entities only when delete is initiated
 					setShowConfirmation(true);
 				}}
 			/>

--- a/libs/ui/lesson/src/lib/lesson-delete-option.tsx
+++ b/libs/ui/lesson/src/lib/lesson-delete-option.tsx
@@ -30,8 +30,8 @@ export function LessonDeleteOption({ lessonId }: { lessonId: string }) {
 			<IconOnlyButton
 				icon={<TrashIcon className="h-5 w-5" />}
 				className="btn-danger"
-				onClick={() => {
-					refetch(); // Lazy-load linked entities only when delete is initiated
+				onClick={async () => {
+					await refetch(); // Lazy-load linked entities only when delete is initiated
 					setShowConfirmation(true);
 				}}
 				title={"Lerneinheit löschen"}

--- a/libs/ui/lesson/src/lib/lesson-delete-option.tsx
+++ b/libs/ui/lesson/src/lib/lesson-delete-option.tsx
@@ -6,9 +6,10 @@ import Link from "next/link";
 
 export function LessonDeleteOption({ lessonId }: { lessonId: string }) {
 	const { mutateAsync: deleteLesson } = trpc.lesson.deleteLesson.useMutation();
-	const { data: linkedEntities, isLoading } = trpc.lesson.findLinkedLessonEntities.useQuery({
-		lessonId
-	});
+	const {
+		data: linkedEntities,
+		refetch
+	} = trpc.lesson.findLinkedLessonEntities.useQuery({ lessonId }, { enabled: false }); // Prevent DB call on page load
 	const [showConfirmation, setShowConfirmation] = useState(false);
 
 	const handleDelete = async () => {
@@ -24,17 +25,15 @@ export function LessonDeleteOption({ lessonId }: { lessonId: string }) {
 		setShowConfirmation(false);
 	};
 
-	// Don't show delete button -> Empty option
-	if (isLoading) {
-		return null;
-	}
-
 	return (
 		<>
 			<IconOnlyButton
 				icon={<TrashIcon className="h-5 w-5" />}
 				className="btn-danger"
-				onClick={() => setShowConfirmation(true)}
+				onClick={() => {
+					refetch(); // Lazy-load linked entities only when delete is initiated
+					setShowConfirmation(true);
+				}}
 				title={"Lerneinheit löschen"}
 			/>
 			{showConfirmation && (


### PR DESCRIPTION
## Problem
DB calls for `course.findLinkedEntities` and `lesson.findLinkedLessonEntities` 
were firing on page load for every course/lesson, causing N unnecessary DB calls. 
This was slowing down the page load significantly, especially for lessons which 
use a heavy raw SQL query with JSON scanning across the entire Course table.

## Root Cause
Both `CourseDeleteOption` and `LessonDeleteOption` components were calling 
`useQuery` unconditionally on render. The data is only needed when the delete 
confirmation dialog is opened, not on page load.

## Fix
- Added `enabled: false` to both queries to prevent firing on render
- Added `refetch()` call on trash button click to lazy-load only when needed
- Removed the `isLoading` early return that was hiding the delete button during load

## Testing
- Verified in browser Network tab that `findLinkedEntities` no longer fires on page load
- Verified that clicking the trash icon correctly triggers the query and opens the dialog with correct data

Refs #491