### PR TITLE
fix(ai-tutor): UI bug in AI-Tutor Chat Pannel

### DIFF
--- a/libs/ui/common/src/lib/dropdown-menu/dropdown-menu.tsx
+++ b/libs/ui/common/src/lib/dropdown-menu/dropdown-menu.tsx
@@ -13,6 +13,7 @@ import { MinorScaleFadeIn } from "@self-learning/ui/common";
  * @param {(focus: boolean) => string} [customFocusStyle] - Optional function to customize class names for focused items.
  * @param {ReactNode} button - The button content that triggers the dropdown (e.g., text or icon).
  * @param {ReactNode} children - Menu items to display inside the dropdown, typically as `<span>` or `<div>`.
+ * @param {number} [z_index=10] - The z-index for the dropdown menu.
  *
  * @example
  * <DropdownMenu
@@ -31,13 +32,15 @@ export function DropdownMenu({
 	dropdownPosition = "bottom",
 	customFocusStyle,
 	button,
-	children
+	children,
+	z_index = 10
 }: {
 	title: string;
 	dropdownPosition?: "top" | "bottom";
 	customFocusStyle?: (focus: boolean) => string;
 	button: ReactNode;
 	children: ReactNode;
+	z_index?: number;
 }) {
 	const buttonRef = useRef<HTMLDivElement>(null);
 	const [menuWidth, setMenuWidth] = useState<number | null>(null);
@@ -68,7 +71,7 @@ export function DropdownMenu({
 							style={{
 								minWidth: buttonRef.current?.offsetWidth || "auto"
 							}}
-							className={`absolute z-10 bg-white shadow-lg max-h-64 overflow-auto text-sm rounded`}
+							className={`absolute z-${z_index} bg-white shadow-lg max-h-64 overflow-auto text-sm rounded`}
 						>
 							{childrenArray.map((element, i) => (
 								<MenuItem key={i}>

--- a/libs/ui/layouts/src/lib/navbar.tsx
+++ b/libs/ui/layouts/src/lib/navbar.tsx
@@ -217,6 +217,7 @@ export function NavbarDropdownMenu({
 					<ChevronDownIcon className="h-6 w-6 text-c-text-muted" />
 				</div>
 			}
+			z_index={30}
 		>
 			<Link
 				href="/dashboard"


### PR DESCRIPTION
### Issue
The issue is in `AI-Tutor` UI. The issue is related to the `z-index` of the `Dropdown-menu` of `navbar`. Navbar have `z-index = 30` but `Dropdown-menu `had `z-index = 10` therefore dropdown menu of navbar is displaying behid` ai-tutor panel` when `ai-tutor` is also open.

### Fix:
I add one optional parameter in` Dropdown-menu` to pass z-index value.

### Before Fix:
<img width="652" height="250" alt="grafik" src="https://github.com/user-attachments/assets/fae0052c-4f01-49fd-b917-d522952257cf" />

### After Fix
<img width="657" height="357" alt="grafik" src="https://github.com/user-attachments/assets/f558c04a-c72a-4075-a1a2-02876d704527" />


close #516 