### PR TITLE
feat(api): Replace Ollama API usage by OpenAI API

### DIFF
--- a/apps/site/pages/admin/llm-config.tsx
+++ b/apps/site/pages/admin/llm-config.tsx
@@ -133,11 +133,11 @@ export default function LlmConfigPage() {
 									{...register("serverUrl")}
 									required
 									className="textfield w-full"
-									placeholder="https://example.com/ollama/api"
+									placeholder="https://example.com/v1"
 								/>
 								<p className="text-sm text-c-text-muted mt-1">
 									{t("Base URL of your LLM server", {
-										url: "https://example.com/ollama/api"
+										url: "https://example.com/v1"
 									})}
 								</p>
 							</div>

--- a/apps/worker-service/project.json
+++ b/apps/worker-service/project.json
@@ -19,7 +19,8 @@
                 "tsConfig": "apps/worker-service/tsconfig.app.json",
 				"assets": ["apps/worker-service/src/assets"],
 				"generatePackageJson": true,
-				"esbuildOptions": {
+				"external": ["onnxruntime-node"],
+                "esbuildOptions": {
 					"sourcemap": true,
 					"outExtension": {
 						".js": ".js"

--- a/apps/worker-service/project.json
+++ b/apps/worker-service/project.json
@@ -20,7 +20,7 @@
 				"assets": ["apps/worker-service/src/assets"],
 				"generatePackageJson": true,
 				"external": ["onnxruntime-node"],
-                "esbuildOptions": {
+				"esbuildOptions": {
 					"sourcemap": true,
 					"outExtension": {
 						".js": ".js"

--- a/libs/data-access/api/src/lib/llm/openai_api_handler.ts
+++ b/libs/data-access/api/src/lib/llm/openai_api_handler.ts
@@ -30,7 +30,7 @@ interface LlmConfig {
  * @param messages Conversation with chat bot, containing of system prompt, user requests, and LLM responses.
  * @param config LLM server configuration including URL, API key, and default model.
  * @param options Additional options to customize the LLM request (e.g., temperature, max_tokens).
- * @returns The content of the LLM's response message. May contain a <think> tag, which is not intended to be rendered on ( or even send to) the client.
+ * @returns The content of the LLM's response message. May contain a <think> tag, which is not intended to be rendered on (or even sent to) the client.
  * @throws TRPCError if there are communication issues with the LLM server or if the response format is invalid.
  */
 export async function sendChatRequest(

--- a/libs/data-access/api/src/lib/llm/openai_api_handler.ts
+++ b/libs/data-access/api/src/lib/llm/openai_api_handler.ts
@@ -1,0 +1,130 @@
+import { TRPCError } from "@trpc/server";
+import { Message } from "@self-learning/ai-tutor";
+import z from "zod";
+
+const llmApiResponseSchema = z.object({
+	choices: z.array(
+		z.object({
+			message: z.object({
+				content: z.string(),
+				role: z.string()
+			})
+		})
+	)
+});
+
+interface LlmConfig {
+	serverUrl: string;
+	apiKey: string | null;
+	defaultModel: string;
+}
+
+/**
+ * Send a chat request to the LLM server with the given messages and configuration.
+ *
+ * This function handles the communication with the LLM server, including error handling and response validation.
+ * It sends a POST request to the LLM server's /chat/completions endpoint with the conversation history and configuration parameters.
+ * The response is expected to contain a choices array with the assistant's reply, which is then validated against a schema.
+ * If the response format is invalid or if there are any communication errors, appropriate TRPC errors are thrown.
+ *
+ * @param messages Conversation with chat bot, containing of system prompt, user requests, and LLM responses.
+ * @param config LLM server configuration including URL, API key, and default model.
+ * @param options Additional options to customize the LLM request (e.g., temperature, max_tokens).
+ * @returns The content of the LLM's response message. May contain a <think> tag, which is not intended to be rendered on ( or even send to) the client.
+ * @throws TRPCError if there are communication issues with the LLM server or if the response format is invalid.
+ */
+export async function sendChatRequest(
+	messages: Message[],
+	config: LlmConfig,
+	options: Record<string, unknown> = {}
+) {
+	const TIMEOUT_MS = 30000; // 30 seconds timeout for LLM response
+	try {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+		const response = await fetch(`${config.serverUrl}/chat/completions`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {})
+			},
+			body: JSON.stringify({
+				messages,
+				model: config.defaultModel,
+				temperature: 0.7,
+				max_tokens: 2000,
+				stream: false,
+
+				...options
+			}),
+			signal: controller.signal
+		});
+
+		clearTimeout(timeout);
+
+		if (!response.ok) {
+			throw handleHttpError(response.status);
+		}
+
+		const data = await response.json();
+		const validated = llmApiResponseSchema.safeParse(data);
+
+		if (!validated.success) {
+			console.error("[LlmClientService] Invalid LLM response format", {
+				errors: validated.error
+			});
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Invalid response format from LLM server"
+			});
+		}
+
+		const firstChoice = validated.data.choices[0];
+
+		if (!firstChoice || typeof firstChoice.message?.content !== "string") {
+			console.error("[LlmClientService] LLM response missing first choice content");
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Invalid response format from LLM server"
+			});
+		}
+
+		return firstChoice.message.content;
+	} catch (error) {
+		if (error instanceof TRPCError) {
+			throw error;
+		}
+
+		if (error instanceof Error && error.name === "AbortError") {
+			console.error("[LlmClientService] Request timeout");
+			throw new TRPCError({
+				code: "TIMEOUT",
+				message: "LLM server request timed out"
+			});
+		}
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "Failed to communicate with LLM server"
+		});
+	}
+}
+
+function handleHttpError(status: number): TRPCError {
+	const error = errorMap[status] || errorMap[500];
+	return new TRPCError({
+		code: error.code,
+		message: error.message
+	});
+}
+
+const errorMap: Record<number, { code: TRPCError["code"]; message: string }> = {
+	400: { code: "BAD_REQUEST", message: "Invalid request to LLM server" },
+	401: { code: "UNAUTHORIZED", message: "LLM API authentication failed" },
+	403: { code: "FORBIDDEN", message: "Access to LLM API forbidden" },
+	404: { code: "NOT_FOUND", message: "LLM API endpoint not found" },
+	429: { code: "TOO_MANY_REQUESTS", message: "LLM API rate limit exceeded" },
+	500: { code: "INTERNAL_SERVER_ERROR", message: "LLM server internal error" },
+	502: { code: "BAD_GATEWAY", message: "LLM server unavailable" },
+	503: { code: "SERVICE_UNAVAILABLE", message: "LLM server temporarily unavailable" }
+};

--- a/libs/data-access/api/src/lib/llm/openai_api_handler.ts
+++ b/libs/data-access/api/src/lib/llm/openai_api_handler.ts
@@ -27,7 +27,7 @@ interface LlmConfig {
  * The response is expected to contain a choices array with the assistant's reply, which is then validated against a schema.
  * If the response format is invalid or if there are any communication errors, appropriate TRPC errors are thrown.
  *
- * @param messages Conversation with chat bot, containing of system prompt, user requests, and LLM responses.
+ * @param messages Conversation with chat bot, containing system prompt, user requests, and LLM responses.
  * @param config LLM server configuration including URL, API key, and default model.
  * @param options Additional options to customize the LLM request (e.g., temperature, max_tokens).
  * @returns The content of the LLM's response message. May contain a <think> tag, which is not intended to be rendered on (or even sent to) the client.

--- a/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
@@ -13,6 +13,7 @@ import { RagRetrievalResult } from "@self-learning/rag-processing";
 import { workerServiceClient } from "@self-learning/worker-api";
 import crypto from "crypto";
 import { z } from "zod";
+import { sendChatRequest } from "../../llm/openai_api_handler";
 
 const aiTutorResponseSchema = z.object({
 	content: z.string(),
@@ -76,7 +77,7 @@ export const aiTutorRouter = t.router({
 		})
 });
 
-async function fetchLlmConfig(): Promise<LlmConfig> {
+async function fetchLlmConfig() {
 	const config = await database.llmConfiguration.findFirst({
 		select: {
 			serverUrl: true,
@@ -94,122 +95,6 @@ async function fetchLlmConfig(): Promise<LlmConfig> {
 
 	return config;
 }
-
-/**
- * Send a chat request to the LLM server with the given messages and configuration.
- *
- * This function handles the communication with the LLM server, including error handling and response validation.
- * It sends a POST request to the LLM server's /chat/completions endpoint with the conversation history and configuration parameters.
- * The response is expected to contain a choices array with the assistant's reply, which is then validated against a schema.
- * If the response format is invalid or if there are any communication errors, appropriate TRPC errors are thrown.
- */
-
-const llmApiResponseSchema = z.object({
-	choices: z.array(
-		z.object({
-			message: z.object({
-				content: z.string(),
-				role: z.string()
-			})
-		})
-	)
-});
-
-interface LlmConfig {
-	serverUrl: string;
-	apiKey: string | null;
-	defaultModel: string;
-}
-
-async function sendChatRequest(messages: Message[], config: LlmConfig): Promise<string> {
-	const TIMEOUT_MS = 30000; // 30 seconds timeout for LLM response
-	try {
-		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-		const response = await fetch(`${config.serverUrl}/chat/completions`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {})
-			},
-			body: JSON.stringify({
-				messages,
-				model: config.defaultModel,
-				temperature: 0.7,
-				max_tokens: 2000,
-				stream: false
-			}),
-			signal: controller.signal
-		});
-
-		clearTimeout(timeout);
-
-		if (!response.ok) {
-			throw handleHttpError(response.status);
-		}
-
-		const data = await response.json();
-		const validated = llmApiResponseSchema.safeParse(data);
-
-		if (!validated.success) {
-			console.error("[LlmClientService] Invalid LLM response format", {
-				errors: validated.error
-			});
-			throw new TRPCError({
-				code: "INTERNAL_SERVER_ERROR",
-				message: "Invalid response format from LLM server"
-			});
-		}
-
-		const firstChoice = validated.data.choices[0];
-
-		if (!firstChoice || typeof firstChoice.message?.content !== "string") {
-			console.error("[LlmClientService] LLM response missing first choice content");
-			throw new TRPCError({
-				code: "INTERNAL_SERVER_ERROR",
-				message: "Invalid response format from LLM server"
-			});
-		}
-
-		return firstChoice.message.content;
-	} catch (error) {
-		if (error instanceof TRPCError) {
-			throw error;
-		}
-
-		if (error instanceof Error && error.name === "AbortError") {
-			console.error("[LlmClientService] Request timeout");
-			throw new TRPCError({
-				code: "TIMEOUT",
-				message: "LLM server request timed out"
-			});
-		}
-		throw new TRPCError({
-			code: "INTERNAL_SERVER_ERROR",
-			message: "Failed to communicate with LLM server"
-		});
-	}
-}
-
-function handleHttpError(status: number): TRPCError {
-	const error = errorMap[status] || errorMap[500];
-	return new TRPCError({
-		code: error.code,
-		message: error.message
-	});
-}
-
-const errorMap: Record<number, { code: TRPCError["code"]; message: string }> = {
-	400: { code: "BAD_REQUEST", message: "Invalid request to LLM server" },
-	401: { code: "UNAUTHORIZED", message: "LLM API authentication failed" },
-	403: { code: "FORBIDDEN", message: "Access to LLM API forbidden" },
-	404: { code: "NOT_FOUND", message: "LLM API endpoint not found" },
-	429: { code: "TOO_MANY_REQUESTS", message: "LLM API rate limit exceeded" },
-	500: { code: "INTERNAL_SERVER_ERROR", message: "LLM server internal error" },
-	502: { code: "BAD_GATEWAY", message: "LLM server unavailable" },
-	503: { code: "SERVICE_UNAVAILABLE", message: "LLM server temporarily unavailable" }
-};
 
 /**
  * Inject (or replace) the system prompt in the message array.

--- a/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
@@ -161,7 +161,18 @@ async function sendChatRequest(messages: Message[], config: LlmConfig): Promise<
 				message: "Invalid response format from LLM server"
 			});
 		}
-		return validated.data.choices[0]?.message?.content ?? "";
+
+		const firstChoice = validated.data.choices[0];
+
+		if (!firstChoice || typeof firstChoice.message?.content !== "string") {
+			console.error("[LlmClientService] LLM response missing first choice content");
+			throw new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Invalid response format from LLM server"
+			});
+		}
+
+		return firstChoice.message.content;
 	} catch (error) {
 		if (error instanceof TRPCError) {
 			throw error;

--- a/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/ai-tutor.router.ts
@@ -99,16 +99,20 @@ async function fetchLlmConfig(): Promise<LlmConfig> {
  * Send a chat request to the LLM server with the given messages and configuration.
  *
  * This function handles the communication with the LLM server, including error handling and response validation.
- * It sends a POST request to the LLM server's /chat endpoint with the conversation history and configuration parameters.
- * The response is expected to contain a message object with the assistant's reply, which is then validated against a schema.
+ * It sends a POST request to the LLM server's /chat/completions endpoint with the conversation history and configuration parameters.
+ * The response is expected to contain a choices array with the assistant's reply, which is then validated against a schema.
  * If the response format is invalid or if there are any communication errors, appropriate TRPC errors are thrown.
  */
 
 const llmApiResponseSchema = z.object({
-	message: z.object({
-		content: z.string(),
-		role: z.string()
-	})
+	choices: z.array(
+		z.object({
+			message: z.object({
+				content: z.string(),
+				role: z.string()
+			})
+		})
+	)
 });
 
 interface LlmConfig {
@@ -123,7 +127,7 @@ async function sendChatRequest(messages: Message[], config: LlmConfig): Promise<
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-		const response = await fetch(`${config.serverUrl}/chat`, {
+		const response = await fetch(`${config.serverUrl}/chat/completions`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -132,10 +136,9 @@ async function sendChatRequest(messages: Message[], config: LlmConfig): Promise<
 			body: JSON.stringify({
 				messages,
 				model: config.defaultModel,
-				stream: false,
 				temperature: 0.7,
-				maxTokens: 2000,
-				timeout: TIMEOUT_MS
+				max_tokens: 2000,
+				stream: false
 			}),
 			signal: controller.signal
 		});
@@ -158,7 +161,7 @@ async function sendChatRequest(messages: Message[], config: LlmConfig): Promise<
 				message: "Invalid response format from LLM server"
 			});
 		}
-		return validated.data.message.content;
+		return validated.data.choices[0]?.message?.content ?? "";
 	} catch (error) {
 		if (error instanceof TRPCError) {
 			throw error;

--- a/libs/data-access/api/src/lib/trpc/routers/llm-config.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/llm-config.router.ts
@@ -2,7 +2,11 @@ import { adminProcedure, authProcedure, t } from "../trpc";
 import { database } from "@self-learning/database";
 import { TRPCError } from "@trpc/server";
 import { secondsToMilliseconds } from "date-fns";
-import { llmConfigSchema, llmConfigSchemaForFetching, ollamaModelList } from "@self-learning/types";
+import {
+	llmConfigSchema,
+	llmConfigSchemaForFetching,
+	openAiModelList
+} from "@self-learning/types";
 
 /**
  * Fetches available models from the LLM server.
@@ -21,7 +25,7 @@ async function fetchAvailableModels(serverUrl: string, apiKey?: string, timeoutS
 
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), secondsToMilliseconds(timeoutSeconds));
-	const response = await fetch(serverUrl + "/tags", {
+	const response = await fetch(serverUrl + "/models", {
 		method: "GET",
 		headers,
 		signal: controller.signal
@@ -35,7 +39,7 @@ async function fetchAvailableModels(serverUrl: string, apiKey?: string, timeoutS
 	}
 
 	const data = await response.json();
-	return ollamaModelList.parse(data);
+	return openAiModelList.parse(data);
 }
 
 export async function fetchLlmConfig() {
@@ -83,9 +87,7 @@ export const llmConfigRouter = t.router({
 
 			try {
 				const availableModels = await fetchAvailableModels(serverUrl, apiKey);
-				const modelExists = availableModels.models.some(
-					m => m.name === defaultModel || m.name.startsWith(defaultModel + ":")
-				);
+				const modelExists = availableModels.data.some(m => m.id === defaultModel);
 
 				if (!modelExists) {
 					throw new TRPCError({
@@ -153,7 +155,7 @@ export const llmConfigRouter = t.router({
 				const availableModels = await fetchAvailableModels(serverUrl, apiKey);
 				return {
 					valid: true,
-					availableModels: availableModels.models.map(m => m.name)
+					availableModels: availableModels.data.map(m => m.id)
 				};
 			} catch (error) {
 				if (error instanceof TRPCError) {

--- a/libs/data-access/api/src/lib/trpc/routers/llm-config.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/llm-config.router.ts
@@ -2,11 +2,7 @@ import { adminProcedure, authProcedure, t } from "../trpc";
 import { database } from "@self-learning/database";
 import { TRPCError } from "@trpc/server";
 import { secondsToMilliseconds } from "date-fns";
-import {
-	llmConfigSchema,
-	llmConfigSchemaForFetching,
-	openAiModelList
-} from "@self-learning/types";
+import { llmConfigSchema, llmConfigSchemaForFetching, openAiModelList } from "@self-learning/types";
 
 /**
  * Fetches available models from the LLM server.

--- a/libs/util/types/src/lib/llm-config.ts
+++ b/libs/util/types/src/lib/llm-config.ts
@@ -11,10 +11,10 @@ export const llmConfigSchemaForFetching = z.object({
 	apiKey: z.string().optional()
 });
 
-export const ollamaModelList = z.object({
-	models: z.array(
+export const openAiModelList = z.object({
+	data: z.array(
 		z.object({
-			name: z.string()
+			id: z.string()
 		})
 	)
 });


### PR DESCRIPTION
This replaces the use of the Ollama specific API endpoint by the OpenAI API, which is also supported by Ollama and other LLM providers and, thus, provides larger support for more LLM servers. As a downside, this requires the re-configuration of base URL of the used LLM server.

Closes #451