### PR TITLE
fix(storage): fix objectName mismatch and orphaned files on delete

### DIFF
--- a/libs/data-access/api/src/lib/trpc/routers/storage.router.ts
+++ b/libs/data-access/api/src/lib/trpc/routers/storage.router.ts
@@ -79,7 +79,9 @@ export const storageRouter = t.router({
 				// TODO: Requires public download option -> Implement download via presignedUrl
 				const downloadUrl = presignedUrl.slice(0, presignedUrl.indexOf("?"));
 
-				return { presignedUrl, downloadUrl };
+				// Return the actual generated object name so callers can register
+				// the correct MinIO key (avoids mismatch with client-generated UUIDs)
+				return { presignedUrl, downloadUrl, objectName: randomizedFilename };
 			} catch (error) {
 				const errMsg: string =
 					error instanceof Error
@@ -229,7 +231,6 @@ export const storageRouter = t.router({
 									})
 								);
 							}
-
 
 							// Detect the entry point
 							const fileName = entryPath.split("/").pop()?.toLowerCase() ?? "";
@@ -396,8 +397,32 @@ async function removeFile(objectName: string) {
 	});
 }
 
-/** Uses the `minio` SDK to remove a file. */
 function _removeFileFromStorageServer(filename: string): Promise<void> {
+	// Unpacked zip/h5p content is stored as multiple objects under a
+	// `content/<id>/...` prefix. The UploadedAssets record stores the
+	// folder prefix itself (e.g. `content/abc123`) as objectName, so we
+	// need to remove all objects under that prefix, not just one key.
+	if (filename.startsWith("content/")) {
+		return new Promise<void>((resolve, reject) => {
+			const objectsToDelete: string[] = [];
+			const stream = minioClient.listObjectsV2(minioConfig.bucketName, `${filename}/`, true);
+
+			stream.on("data", obj => {
+				if (obj.name) objectsToDelete.push(obj.name);
+			});
+			stream.on("error", reject);
+			stream.on("end", () => {
+				if (objectsToDelete.length === 0) {
+					return resolve();
+				}
+				minioClient
+					.removeObjects(minioConfig.bucketName, objectsToDelete)
+					.then(() => resolve())
+					.catch(reject);
+			});
+		});
+	}
+
 	return minioClient.removeObject(minioConfig.bucketName, filename);
 }
 

--- a/libs/ui/forms/src/lib/upload.tsx
+++ b/libs/ui/forms/src/lib/upload.tsx
@@ -96,26 +96,27 @@ export function Upload({
 
 		console.log(file);
 
-		const objectName = window.crypto.randomUUID();
 		const fileName = file.name;
 		setFileName(fileName);
 		const fileType = tryGetMediaType(file) ?? "unknown";
-
 		const meta = {
 			duration: 0
 		};
 		if (mediaType === "video") {
 			const vid = document.createElement("video");
 			vid.src = URL.createObjectURL(file);
-
 			vid.onloadedmetadata = () => {
 				meta.duration = Math.floor(vid.duration);
 			};
 		}
-
 		try {
-			const { presignedUrl, downloadUrl } = await getPresignedUrl({ filename: objectName });
-
+			// Use the original filename as a hint; the server generates the
+			// actual unique object key and returns it so we can register the
+			// correct MinIO key (avoids mismatch between client-generated UUIDs
+			// and the server's randomized filename).
+			const { presignedUrl, downloadUrl, objectName } = await getPresignedUrl({
+				filename: fileName
+			});
 			const onFinish = (xhr: XMLHttpRequest) => {
 				const success = xhr.status >= 200 && xhr.status < 300;
 				console.log(
@@ -136,7 +137,6 @@ export function Upload({
 				setProgress,
 				onFinish
 			);
-
 			try {
 				// TODO: Requires public download option -> Implement download via presignedUrl
 				await registerAsset({ objectName, publicUrl: downloadUrl, fileType, fileName });

--- a/libs/util/types/src/lib/asset.ts
+++ b/libs/util/types/src/lib/asset.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const uploadedAssetSchema = z.object({
-	objectName: z.string().uuid(),
+	objectName: z.string().min(1),
 	fileName: z.string().min(1),
 	fileType: z.string().min(1),
 	publicUrl: z.string().url()


### PR DESCRIPTION
- getPresignedUrl now returns the actual generated object key so registerAsset stores the real MinIO key instead of an unrelated client-generated UUID
- Relax uploadedAssetSchema objectName validation from strict UUID to non-empty string since the real key includes the filename
- removeFile now detects content/ folder prefixes (unpacked zip/h5p) and deletes all objects under that prefix, preventing orphaned files in MinIO when a user deletes an unpacked asset

Refs #533